### PR TITLE
Parameter constraints

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -24,7 +24,7 @@ var RESERVED_PROPS = {
 /**
  * <Route> components specify components that are rendered to the page when the
  * URL matches a given pattern.
- * 
+ *
  * Routes are arranged in a nested tree structure. When a new URL is requested,
  * the tree is searched depth-first to find a route whose path matches the URL.
  * When one is found, all routes in the tree that lead to it are considered
@@ -250,7 +250,9 @@ function Redirect(to, params, query) {
 }
 
 function findMatches(path, route) {
-  var children = route.props.children, matches;
+  var children  = route.props.children,
+    constraints = route.props.constraints || {},
+    matches;
 
   // Check the subtree first to find the most deeply-nested match.
   if (Array.isArray(children)) {
@@ -275,7 +277,7 @@ function findMatches(path, route) {
   }
 
   // No routes in the subtree matched, so check this route.
-  var params = Path.extractParams(route.props.path, path);
+  var params = Path.extractParams(route.props.path, path, constraints);
 
   if (params)
     return [ makeMatch(route, params) ];

--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -39,7 +39,7 @@ var Path = {
    * and returns an object of param name => value pairs. Returns null if the
    * pattern does not match the given path.
    */
-  extractParams: function (pattern, path) {
+  extractParams: function (pattern, path, constraints) {
     if (!isDynamicPattern(pattern)) {
       if (pattern === decodeURIComponent(path))
         return {}; // No dynamic segments, but the paths match.
@@ -53,13 +53,17 @@ var Path = {
     if (!match)
       return null;
 
-    var params = {};
+    var params = {},
+        constraintsPassed = true;
 
     compiled.paramNames.forEach(function (paramName, index) {
+      if (constraints[paramName] && ! constraints[paramName].test(match[index + 1]))
+        constraintsPassed = false;
+
       params[paramName] = match[index + 1];
     });
 
-    return params;
+    return constraintsPassed ? params : null;
   },
 
   /**

--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -69,9 +69,6 @@ var Path = {
   testConstraints: function (params, constraints) {
     var pass = true;
 
-    if (! constraints || constraints === {})
-      return true;
-
     Object.keys(params).forEach(function(param) {
       if (constraints[param]) {
         if (! constraints[param].test(params[param])) {

--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -53,17 +53,34 @@ var Path = {
     if (!match)
       return null;
 
-    var params = {},
-        constraintsPassed = true;
+    var params = {};
 
     compiled.paramNames.forEach(function (paramName, index) {
-      if (constraints[paramName] && ! constraints[paramName].test(match[index + 1]))
-        constraintsPassed = false;
-
       params[paramName] = match[index + 1];
     });
 
-    return constraintsPassed ? params : null;
+    if (this.testConstraints(params, constraints)) {
+      return params;
+    }
+
+    return null;
+  },
+
+  testConstraints: function (params, constraints) {
+    var pass = true;
+
+    if (! constraints || constraints === {})
+      return true;
+
+    Object.keys(params).forEach(function(param) {
+      if (constraints[param]) {
+        if (! constraints[param].test(params[param])) {
+          pass = false;
+        }
+      }
+    });
+
+    return pass;
   },
 
   /**

--- a/modules/helpers/Path.js
+++ b/modules/helpers/Path.js
@@ -71,6 +71,10 @@ var Path = {
   testConstraints: function (params, constraints) {
     var pass = true;
 
+    if (! constraints) {
+      return true;
+    }
+
     Object.keys(params).forEach(function(param) {
       if (constraints[param]) {
         if (! constraints[param].test(params[param])) {

--- a/specs/Path.spec.js
+++ b/specs/Path.spec.js
@@ -81,6 +81,23 @@ describe('Path.extractParams', function () {
       });
     });
   });
+
+  describe('when a pattern has dynamic segments with constraints', function() {
+    var pattern = '/comments/:id/edit',
+        constraints = {
+            id : /\d+/
+        };
+
+    describe('and the constraints match', function() {
+        expect(Path.extractParams(pattern, '/comments/123/edit', constraints))
+            .toEqual({ id : 123 });
+    });
+
+    describe('and the constraints do not match', function() {
+        expect(Path.extractParams(pattern, '/comments/abc/edit', constraints))
+            .toBe(null);
+    });
+  });
 });
 
 describe('Path.extractParamNames', function () {
@@ -118,7 +135,7 @@ describe('Path.injectParams', function () {
     describe('and a param is missing', function () {
       it('throws an Error', function () {
         expect(function () {
-          Path.injectParams(pattern, {})
+          Path.injectParams(pattern, {});
         }).toThrow(Error);
       });
     });
@@ -180,5 +197,35 @@ describe('Path.normalize', function () {
     it('reduces them to a single slash', function () {
       expect(Path.normalize('//a/b/c')).toEqual('/a/b/c');
     });
+  });
+});
+
+describe('Path.testConstraints', function () {
+  it('returns false when one or more constraints fail', function () {
+    var params = {
+      id   : 123,
+      name : 'Abc'
+    };
+
+    var constraints = {
+      id : /^\d+$/,
+      name : /^[a-z]+$/
+    };
+
+    expect(Path.testConstraints(params, constraints)).toBe(false);
+  });
+
+  it('returns true when constraints pass', function () {
+    var params = {
+      id   : 123,
+      name : 'Abc'
+    };
+
+    var constraints = {
+      id : /^\d+$/,
+      name : /^[A-Za-z]+$/
+    };
+
+    expect(Path.testConstraints(params, constraints)).toBe(true);
   });
 });


### PR DESCRIPTION
Adds the ability to specify regex constraints for param values on individual routes. Example:

```javascript

var constraints = { id : /^\d+/, action: /^(create|read|update|delete)$/ };
React.renderComponent((
    <Route handler={SiteWrapper}>
        <Route name='posts' handler={PostPage} path='/posts/:id/:action' constraints={constraints} />
        <Route name='404' handler={NotFoundPage} path='*' />
    </Route>
), document.body);

```

In this example, the path `/posts/123/read` will route to `PostPage`, while the paths `/posts/abc/read` and `/posts/123/foobar` will route to `NotFoundPage`.