### PR TITLE
Allow transition hooks access to a context object you can specify when you create the router.

### DIFF
--- a/docs/api/Transition.md
+++ b/docs/api/Transition.md
@@ -23,3 +23,20 @@ entry in the browser history.
 
   [transition-hooks]:/docs/api/components/RouteHandler.md#static-lifecycle-methods
 
+### `context`
+
+An optional context object that can be accessed by the willTransitionTo and
+willTransitionFrom static methods on components.
+
+When creating the router instance:
+
+    var context = {};
+    Router.create({transitionContext: context});
+
+And then in a component:
+
+    statics: {
+      willTransitionTo: function(transition) {
+        //do something with transition.context
+      }
+    }

--- a/modules/TestUtils.js
+++ b/modules/TestUtils.js
@@ -118,3 +118,17 @@ exports.EchoBarParam = React.createClass({
     return <div className="EchoBarParam">{this.context.router.getCurrentParams().bar}</div>;
   }
 });
+
+exports.TransitionContext = React.createClass({
+  statics: {
+    willTransitionTo: function (transition) {
+      var service = transition.context.getService();
+      if (!service.isLoggedIn) {
+        transition.redirect('/foo');
+      }
+    }
+  },
+  render: function() {
+    return <div>TransitionContext</div>
+  }
+});

--- a/modules/Transition.js
+++ b/modules/Transition.js
@@ -9,11 +9,12 @@ var Redirect = require('./Redirect');
  * The willTransitionTo and willTransitionFrom handlers receive
  * an instance of this class as their first argument.
  */
-function Transition(path, retry) {
+function Transition(path, retry, context) {
   this.path = path;
   this.abortReason = null;
   // TODO: Change this to router.retryTransition(transition)
   this.retry = retry.bind(this);
+  this.context = context;
 }
 
 Transition.prototype.abort = function (reason) {

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -18,7 +18,8 @@ var {
   RedirectToFoo,
   RedirectToFooAsync,
   Abort,
-  AbortAsync
+  AbortAsync,
+  TransitionContext
 } = require('../TestUtils');
 
 describe('Router', function () {
@@ -32,7 +33,8 @@ describe('Router', function () {
       <Route path="/foo" handler={Foo}/>,
       <Route path="/bar" handler={Bar}/>,
       <Route path="/baz" handler={Baz}/>,
-      <Route path="/async" handler={Async}/>
+      <Route path="/async" handler={Async}/>,
+      <Route path="/transition-context" handler={TransitionContext}/>
     ];
 
     describe('asynchronous willTransitionTo', function () {
@@ -634,6 +636,36 @@ describe('Router', function () {
             steps.shift()();
           });
         });
+      });
+    });
+
+    describe('transition.context', function() {
+      it('can provide a context object to the transition hooks', function(done) {
+        var location = new TestLocation([ '/transition-context' ]);
+
+        //if isLoggedIn is false, will redirect to /foo otherwise shows /transition-context
+        var transitionContext = {
+          getService: function() {
+            return {
+              isLoggedIn: true
+            }
+          }
+        };
+
+        var router = Router.create({
+          routes: routes,
+          location: location,
+          transitionContext: transitionContext
+        });
+
+        var div = document.createElement('div');
+        router.run(function(Handler){
+          React.render(<Handler/>, div, function () {
+            expect(div.innerHTML).toMatch(/TransitionContext/);
+            done();
+          });
+        });
+
       });
     });
   });

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -370,7 +370,7 @@ function createRouter(options) {
           toRoutes = nextRoutes;
         }
 
-        var transition = new Transition(path, Router.replaceWith.bind(Router, path));
+        var transition = new Transition(path, Router.replaceWith.bind(Router, path), options.transitionContext);
         pendingTransition = transition;
 
         var fromComponents = mountedComponents.slice(prevRoutes.length - fromRoutes.length);


### PR DESCRIPTION
I've been trying to make an authentication mixin that can access the state in one of my flux stores but am not using singletons that I can make available to the static methods. Would it be alright to pass a context object through to the static willTransition hook methods to allow them access to arbitrary services you might need?

        var context = {...}
        Router.create({routes: routes, transitionContext: context})

        statics: {
          willTransitionTo: function(transition) {
             var loginState = transition.context.getStore(LoginStore).getState();
          }
        }

