### PR TITLE
Replace when.js with promises in example app

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -1,6 +1,5 @@
 var React = require('react');
 var Router = require('react-router');
-var whenKeys = require('when/keys');
 var EventEmitter = require('events').EventEmitter;
 var { Route, DefaultRoute, RouteHandler, Link } = Router;
 
@@ -120,12 +119,13 @@ var routes = (
 );
 
 function fetchData(routes, params) {
-  return whenKeys.all(routes.filter((route) => {
-    return route.handler.fetchData;
-  }).reduce((data, route) => {
-    data[route.name] = route.handler.fetchData(params);
-    return data;
-  }, {}));
+  var data = {};
+  return Promise.all(routes
+    .filter(route => route.handler.fetchData)
+    .map(route => {
+      return route.handler.fetchData(params).then(d => {data[route.name] = d;});
+    })
+  ).then(() => data);
 }
 
 Router.run(routes, function (Handler, state) {


### PR DESCRIPTION
On new installs the examples don't compile. That's because when.js had been removed as a dependency in #654. This PR fixes it by replacing the use of when.js with promises.