### PR TITLE
Fix server side error in supportsHistory()

### DIFF
--- a/modules/utils/supportsHistory.js
+++ b/modules/utils/supportsHistory.js
@@ -4,6 +4,10 @@ function supportsHistory() {
    * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
    * changed to avoid false negatives for Windows Phones: https://github.com/rackt/react-router/issues/586
    */
+  if (typeof window === 'undefined') {
+    return false;
+  } 
+   
   var ua = navigator.userAgent;
   if ((ua.indexOf('Android 2.') !== -1 ||
       (ua.indexOf('Android 4.0') !== -1)) &&


### PR DESCRIPTION
This fix checks for the existence of the window variable in the supportsHistory() function and returns false if it is missing. Allows error-free server side routing. 

There may be a cleaner way to check this.