### PR TITLE
Ignore stale transitions

### DIFF
--- a/modules/utils/createRouter.js
+++ b/modules/utils/createRouter.js
@@ -410,11 +410,15 @@ function createRouter(options) {
         );
 
         var dispatchHandler = function (error, transition) {
+          if (error)
+            onError.call(router, error);
+
+          if (pendingTransition !== transition)
+            return;
+
           pendingTransition = null;
 
-          if (error) {
-            onError.call(router, error);
-          } else if (transition.isAborted) {
+          if (transition.isAborted) {
             onAbort.call(router, transition.abortReason, location);
           } else {
             callback.call(router, router, nextState);


### PR DESCRIPTION
Currently, the dispatchHandler doesn't distinguish between stale (superseded) async transitions and the current (pending) ones. This works fine in most cases since a new transition will cause a cancellation of the current one. So when the old transition is finished, the router will call the abort handler which will simply ignore it.

However, I found two problems with this:

1. Besides executing the no-op abort handler, finishDispatch also sets pendingTransition to null.  This can be a problem if a stale transition ends while another async one is in progress. If a third transition occurs, the router tries to cancel the ongoing one as usual, but its reference was removed after the completion of the first transition. As a result, that transition will go through once it is complete.

2. If an async transition is aborted, but another transition is started before it completes, the router will still manipulate the history stack when completed (pop for abort, replace for redirect). This is because the cancellation by the router is ignored if the transition has already been aborted.
It can not happen if you always call the callback immediately after aborting the transition.

The PR contains tests for those two cases, as well as a possible fix. 