### PR TITLE
Revert "[fixed] Path.withQuery strips query if query is empty"

### DIFF
--- a/modules/utils/Path.js
+++ b/modules/utils/Path.js
@@ -149,7 +149,7 @@ var Path = {
     if (queryString)
       return Path.withoutQuery(path) + '?' + queryString;
 
-    return Path.withoutQuery(path);
+    return path;
   },
 
   /**

--- a/modules/utils/__tests__/Path-test.js
+++ b/modules/utils/__tests__/Path-test.js
@@ -321,10 +321,6 @@ describe('Path.withQuery', function () {
     expect(Path.withQuery('/a/b/c', { id: 'def' })).toEqual('/a/b/c?id=def');
   });
 
-  it('removes query string', function () {
-    expect(Path.withQuery('/a/b/c?a=b', { a: undefined })).toEqual('/a/b/c');
-  });
-
   it('merges two query strings', function () {
     expect(Path.withQuery('/path?a=b', { c: [ 'd', 'e' ]})).toEqual('/path?a=b&c%5B0%5D=d&c%5B1%5D=e');
   });


### PR DESCRIPTION
Reverts rackt/react-router#599

This test is failing. :(