### PR TITLE
Capitalize `node.buffer`-option

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   node: {
-    buffer: false
+    Buffer: false
   },
 
   plugins: plugins


### PR DESCRIPTION
Since [webpack 1.5](http://webpack.github.io/docs/changelog.html#1-5) the casing of `buffer` has been changed to `Buffer` (because it refers to the global `Buffer` variable)