### PR TITLE
[changed] Don't restore scroll position on Forward

### DIFF
--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -344,7 +344,7 @@ function createRouter(options) {
 
         // Record the scroll position as early as possible to
         // get it before browsers try update it automatically.
-        if (prevPath && action !== LocationActions.REPLACE)
+        if (prevPath && action === LocationActions.PUSH)
           this.recordScrollPosition(prevPath);
 
         var match = this.match(path);


### PR DESCRIPTION
We can't reliably restore scroll position on Forward due to browser differences and incompatibilities.
Instead, we will only restore previous scroll position when user presses Back, and scroll to top on Forward.

Fixes #707.