### PR TITLE
[fixed] Ignore falsy routes

### DIFF
--- a/tests/Router-test.js
+++ b/tests/Router-test.js
@@ -832,6 +832,20 @@ describe('Router.run', function () {
     });
   });
 
+  it('does not break on falsy routes', function (done) {
+    var routes = [
+      <Route handler={Foo} path="/foo"/>,
+      null,
+      <Route handler={Bar} path="/bar"/>,
+      undefined
+    ];
+    Router.run(routes, '/foo', function (Handler, state) {
+      var html = React.renderToString(<Handler/>);
+      expect(html).toMatch(/Foo/);
+      done();
+    });
+  });  
+
   it('matches nested routes', function (done) {
     var routes = (
       <Route handler={Nested} path='/'>

--- a/utils/createRoutesFromChildren.js
+++ b/utils/createRoutesFromChildren.js
@@ -154,8 +154,8 @@ function createRoutesFromChildren(children, parentRoute, namedRoutes) {
   var routes = [];
 
   React.Children.forEach(children, function (child) {
-    // Exclude <DefaultRoute>s and <NotFoundRoute>s.
-    if (child = createRoute(child, parentRoute, namedRoutes))
+    // Exclude null values, <DefaultRoute>s and <NotFoundRoute>s.
+    if (child && (child = createRoute(child, parentRoute, namedRoutes)))
       routes.push(child);
   });
 


### PR DESCRIPTION
I just tried to do something like this:

```jsx
<Route name="app" path="/" handler={Application}>
      <Route name="job" path="job/:job_id/?" handler={JobLayout}>
          <Route name="report" handler={Report} />
          {__DEBUG__ && <Route name="debug" handler={Debug} />}
          <DefaultRoute handler={JobForm} />
     </Route>
</Route>
```

Where the `__DEBUG__` var is injected via webpack at compile time. This works fine during development, but in production, the line becomes equivalent to `{undefined}`. This pattern for conditionally rendering nodes is fairly common in React. I thought it might make sense to allow this here by skipping over falsy values in the `createRoutesFromChildren` function.