### PR TITLE
Test makePath with optional trailing slash (failing test)

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -1173,7 +1173,7 @@ describe('Router.run', function () {
     beforeEach(function () {
       router = Router.create({
         routes: [
-          <Route name="home" handler={Foo}>
+          <Route name="home" handler={Foo} path="/?">
             <Route name="users" handler={Foo}>
               <Route name="user" path=":id" handler={Foo}/>
             </Route>


### PR DESCRIPTION
Causes tests to fail, illustrating issue #768

This probably deserves a new test scenario, but there are a lot of edge cases that currently aren't being tested for `makePath()`.