### PR TITLE
Make link's "to=" prop optional

### DIFF
--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -11,6 +11,8 @@ Props
 ### `to`
 
 The name of the route to link to, or a full URL.
+If an empty string is passed, the Link's target will be the currently
+active route.
 
 ### `params`
 
@@ -27,6 +29,10 @@ Object, the parameters to fill in the dynamic segments of your route.
 
 // though, if your user properties match up to the dynamic segements:
 <Link to="user" params={user}/>
+
+// assuming the /users/:userId route is active,
+// change the active user like this
+<Link to="" params={{userId: "456"}}/>
 ```
 
 ### `query`
@@ -68,4 +74,3 @@ active -->
 <!-- change the activeClassName -->
 <Link activeClassName="current" to="user" params={{userId: user.id}}>{user.name}</Link>
 ```
-

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -67,14 +67,25 @@ var Link = React.createClass({
     event.preventDefault();
 
     if (allowTransition)
-      this.transitionTo(this.props.to, this.props.params, this.props.query);
+      this.transitionTo(this.getTo(), this.props.params, this.props.query);
+  },
+
+  /**
+   * Returns the value of the 'to' prop if specified, otherwise returns the
+   * name of the currently active route.
+   */
+  getTo: function() {
+    if (this.props.to)
+      return this.props.to;
+    var currentRoutes = this.context.getCurrentRoutes()
+    return currentRoutes[currentRoutes.length - 1].name
   },
 
   /**
    * Returns the value of the "href" attribute to use on the DOM element.
    */
   getHref: function () {
-    return this.makeHref(this.props.to, this.props.params, this.props.query);
+    return this.makeHref(this.getTo(), this.props.params, this.props.query);
   },
 
   /**
@@ -87,7 +98,7 @@ var Link = React.createClass({
     if (this.props.className)
       classNames[this.props.className] = true;
 
-    if (this.isActive(this.props.to, this.props.params, this.props.query))
+    if (this.isActive(this.getTo(), this.props.params, this.props.query))
       classNames[this.props.activeClassName] = true;
 
     return classSet(classNames);

--- a/modules/components/__tests__/Link-test.js
+++ b/modules/components/__tests__/Link-test.js
@@ -33,6 +33,28 @@ describe('A Link', function () {
         });
       });
     });
+
+    it('knows how to make its href when `to=""`', function () {
+      var LinkHandler = React.createClass({
+        render: function () {
+          return <Link to="" query={{qux: 'quux'}}>Link</Link>;
+        }
+      });
+
+      var routes = [
+        <Route name="link" handler={LinkHandler} />
+      ];
+
+      var div = document.createElement('div');
+      TestLocation.history = [ '/link' ];
+
+      Router.run(routes, TestLocation, function (Handler) {
+        React.render(<Handler/>, div, function () {
+          var a = div.querySelector('a');
+          expect(a.getAttribute('href')).toEqual('/link?qux=quux');
+        });
+      });
+    });
   });
 
   describe('when its route is active', function () {


### PR DESCRIPTION
Here's a humble stab at making `to=` in the Link component optional.