### PR TITLE
[fixed] Double slash in href when parent route has optional trailing sla...

### DIFF
--- a/modules/utils/Path.js
+++ b/modules/utils/Path.js
@@ -4,7 +4,7 @@ var qs = require('qs');
 
 var paramCompileMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|[*.()\[\]\\+|{}^$]/g;
 var paramInjectMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$?]*[?]?)|[*]/g;
-var paramInjectTrailingSlashMatcher = /\/\/\?|\/\?/g;
+var paramInjectTrailingSlashMatcher = /\/\/\?|\/\?\/|\/\?/g;
 var queryMatcher = /\?(.+)/;
 
 var _compiledPatterns = {};

--- a/modules/utils/__tests__/Path-test.js
+++ b/modules/utils/__tests__/Path-test.js
@@ -274,6 +274,12 @@ describe('Path.injectParams', function () {
       expect(Path.injectParams('/foo.bar.baz')).toEqual('/foo.bar.baz');
     });
   });
+
+  describe('when a pattern has optional slashes', function () {
+    it('returns the correct path', function () {
+      expect(Path.injectParams('/foo/?/bar/?/baz/?')).toEqual('/foo/bar/baz/');
+    });
+  });
 });
 
 describe('Path.extractQuery', function () {


### PR DESCRIPTION
...sh

When a parent route of a child route has an optional trailing slash, the
generated path for the child route will have two slashes in a row. Fix
the trailing slash matcher pattern to account for this case.

This bug occurs when calling `Path.injectParams(pattern, params)` to
generate a path. The `pattern` for the path of a child route whose
parent has an optional trailing slash looks something like
`parent/?/child`. If we just replace `/?` with `/` we end up with
`parent//child`, so we need to replace `/?/` with `/`.

This fixes issue #768.