### PR TITLE
[fixed] Reset mountedComponents array when routing, to avoid leaking component references if the mount depth decreases.

### DIFF
--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -384,6 +384,7 @@ function createRouter(options) {
         pendingTransition = transition;
 
         var fromComponents = mountedComponents.slice(prevRoutes.length - fromRoutes.length);
+        mountedComponents = [];
 
         transition.from(fromRoutes, fromComponents, function (error) {
           if (error || transition.abortReason)


### PR DESCRIPTION
I'm currently developing an application with a route structure like so:
```jsx
<Route name="app" path="/" handler={App}>
  <Route name="search" path="search" handler={SearchResults}/>
  <Route name="result" path="result/:resultId" handler={ResultPage}>
    <DefaultRoute name="resultDetail" handler={ResultDetail}/>
    <Route name="relatedResults" path="related" handler={RelatedResults}/>
  </Route>
</Route>
```
Whenever I transition from one of the two child routes of ResultPage to the SearchResults route, the `mountedComponents` variable inside createRouter.js leaks a reference to the child route, as no component will overwrite it with a call to `setRouteComponentAtDepth`. This could potentially leak a large amount of memory through references to props, etc.

This PR fixes that by recreating the array with every route dispatch. I'm not sure how to create a test specifically for this, as it just changes an internal variable's behavior, and the failing case is a silent memory leak.