### PR TITLE
[added] `replace` prop on `Link` component to use `replaceWith()` over `transitionTo()` navigation method

### DIFF
--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -46,6 +46,11 @@ tag - calling `e.preventDefault()` or returning `false` will prevent the
 transition from firing, while `e.stopPropagation()` will prevent the event
 from bubbling.
 
+### `replace`
+
+Boolean declaring whether to use `replaceWith()` instead of `transitionTo()`
+when the user clicks on the link.
+
 ### *others*
 
 You can also pass props you'd like to be on the `<a>` such as a title, id, or className.

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -42,7 +42,8 @@ var Link = React.createClass({
     to: PropTypes.string.isRequired,
     params: PropTypes.object,
     query: PropTypes.object,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    replace: PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -66,8 +67,12 @@ var Link = React.createClass({
 
     event.preventDefault();
 
-    if (allowTransition)
-      this.transitionTo(this.props.to, this.props.params, this.props.query);
+    if (allowTransition) {
+      if (this.props.replace)
+        this.replaceWith(this.props.to, this.props.params, this.props.query);
+      else
+        this.transitionTo(this.props.to, this.props.params, this.props.query);
+    }
   },
 
   /**

--- a/modules/components/__tests__/Link-test.js
+++ b/modules/components/__tests__/Link-test.js
@@ -162,4 +162,46 @@ describe('A Link', function () {
 
   });
 
+  describe('when replace=true', function () {
+
+    it('transitions to the correct route and does *not* create new entry in history', function (done) {
+      var div = document.createElement('div');
+      TestLocation.history = [ '/link' ];
+
+      var LinkHandler = React.createClass({
+        handleClick: function () {
+          // just here to make sure click handlers don't prevent it from happening
+        },
+
+        render: function () {
+          return <Link to="foo" replace={true} onClick={this.handleClick}>Link</Link>;
+        }
+      });
+
+      var routes = [
+        <Route name="foo" handler={Foo} />,
+        <Route name="link" handler={LinkHandler} />
+      ];
+
+      var steps = [];
+
+      steps.push(function () {
+        click(div.querySelector('a'), {button: 0});
+      });
+
+      steps.push(function () {
+        expect(div.innerHTML).toMatch(/Foo/);
+        expect(TestLocation.history.length).toBe(1);
+        done();
+      });
+
+      Router.run(routes, TestLocation, function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
The use case I've had where I need this functionality is when developing a mobile application you will often not want many new entries into the history for sub tabs within a screen. Ie. the user should be one 'back' tap away from the previous parent route. Allowing us to use react-router to compose views nicely and not become too intrusive to user navigation.

Think of when you browse a large gallery online and it remembers the history of each image you clicked on. To get back to the parent you have to spam the 'back' button *a lot* unless there is a more obvious quick route back. On websites you usually have the space to have a heirarcheal navigation but often there is not the real estate on mobile devices so you rely on natural back and forth transitions for the user.

I'd also argue there should be functionality to transition to a route without any history modification (ie. a parent route is always the 'master' and children are not remembered for when you navigate further) but I think that is for a separate PR.

Let me know if there are any thoughts!