### PR TITLE
[fixed] Clean up mounted route component on unmount so we don't leak references

### DIFF
--- a/modules/RouteHandlerMixin.js
+++ b/modules/RouteHandlerMixin.js
@@ -30,6 +30,10 @@ var RouteHandlerMixin = {
     this._updateRouteComponent();
   },
 
+  componentWillUnmount: function () {
+    this.context.setRouteComponentAtDepth(this.getRouteDepth(), null);
+  },
+
   _updateRouteComponent: function () {
     this.context.setRouteComponentAtDepth(this.getRouteDepth(), this.refs[REF_NAME]);
   },


### PR DESCRIPTION
See #778

This commit ensures that we don't leak references to a component if the route depth decreases when navigating to a new route.