### PR TITLE
added default handler to routes

### DIFF
--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -1,7 +1,7 @@
 var React = require('react');
 var Configuration = require('../Configuration');
 var PropTypes = require('../PropTypes');
-
+var RouteHandler = require('./RouteHandler');
 /**
  * <Route> components specify components that are rendered to the page when the
  * URL matches a given pattern.
@@ -39,6 +39,8 @@ var PropTypes = require('../PropTypes');
  *       );
  *     }
  *   });
+ *
+ * If no handler is provided for the route, it will render a matched child route.
  */
 var Route = React.createClass({
 
@@ -49,8 +51,16 @@ var Route = React.createClass({
   propTypes: {
     name: PropTypes.string,
     path: PropTypes.string,
-    handler: PropTypes.func.isRequired,
+    handler: PropTypes.func,
     ignoreScrollBehavior: PropTypes.bool
+  },
+
+  getDefaultProps: function(){
+  	return {
+  	  handler: React.createClass({
+  	    render: function(){ return React.createElement(RouteHandler, React.__spread({},  this.props)); }
+  	  })
+  	};
   }
 
 });

--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -56,11 +56,11 @@ var Route = React.createClass({
   },
 
   getDefaultProps: function(){
-  	return {
-  	  handler: React.createClass({
-  	    render: function(){ return React.createElement(RouteHandler, React.__spread({},  this.props)); }
-  	  })
-  	};
+    return {
+      handler: React.createClass({
+        render: function(){ return React.createElement(RouteHandler, React.__spread({},  this.props)); }
+      })
+    };
   }
 
 });

--- a/modules/components/Route.js
+++ b/modules/components/Route.js
@@ -57,9 +57,7 @@ var Route = React.createClass({
 
   getDefaultProps: function(){
     return {
-      handler: React.createClass({
-        render: function(){ return React.createElement(RouteHandler, React.__spread({},  this.props)); }
-      })
+      handler: RouteHandler
     };
   }
 

--- a/modules/components/__tests__/Route-test.js
+++ b/modules/components/__tests__/Route-test.js
@@ -1,0 +1,38 @@
+var expect = require('expect');
+var React = require('react');
+var Router = require('../../index');
+var DefaultRoute = require('../DefaultRoute');
+var Route = require('../Route');
+var { Foo, Bar } = require('../../utils/TestHandlers');
+
+describe('Route', function () {
+
+  it('renders default child route if path match but no handler provided', function () {
+    var routes = (
+      <Route path='/'>
+        <Route path='/bar' handler={Bar} />
+        <DefaultRoute handler={Foo} />
+      </Route>
+    );
+
+    Router.run(routes, '/', function (App) {
+      var html = React.renderToString(<App/>);
+      expect(html).toMatch(/Foo/);
+    });
+  });
+
+  it('renders matched child route if no handler provided', function () {
+    var routes = (
+      <Route path='/'>
+        <Route path='/bar' handler={Bar} />
+        <DefaultRoute handler={Foo} />
+      </Route>
+    );
+
+    Router.run(routes, '/bar', function (App) {
+      var html = React.renderToString(<App/>);
+      expect(html).toMatch(/Bar/);
+    });
+  });
+
+});


### PR DESCRIPTION
This PR makes the `handler` prop for `Route` non-mandatory. If no handler is provided a default handler will be used that simply renders the current `RouteHandler`. 

This is useful when I have a top level tab without any contents of its own, but still want to have a navlink to it. Consider your [overview example](https://github.com/rackt/react-router/blob/master/docs/guides/overview.md). Let's say I don't want to always show the list of messages on the left. First when I click the "Inbox" tab I see the list, clicking a message lets me see just the message, no list. All the while I want the "Inbox" tab to show as active. That means two child routes to the inbox tab, but no actual content tied to the inbox path. This PR lets me do this:

```javascript
<Route path="/inbox">
  <DefaultRoute handler={List} />
  <Route path="/inbox/:messageid" handler={Message} />
</Route>
```

While before I've solved this problem like this:

```javascript
<Route path="/inbox" handler={Multiroute}>
  <DefaultRoute handler={List} />
  <Route path="/inbox/:messageid" handler={Message} />
</Route>
```

Where `Multiroute` is a simple dummy component rendering the active child:

```javascript
var Multiroute = React.createClass({
  render: function(){
    return <RouteHandler {...this.props} />;
  }
});
```

This dummy component is what this PR now uses as a default handler.