### PR TITLE
[added] I added the ability to define Routes in the static section of the handler

### DIFF
--- a/modules/Routing.js
+++ b/modules/Routing.js
@@ -122,6 +122,10 @@ function createRoute(element, parentRoute, namedRoutes) {
 
   route.routes = createRoutesFromReactChildren(props.children, route, namedRoutes);
 
+  if (props.handler && props.handler.routes){
+    route.routes = route.routes.concat(createRoutesFromReactChildren(props.handler.routes, route, namedRoutes));
+  }
+
   return route;
 }
 

--- a/modules/__tests__/Routing-test.js
+++ b/modules/__tests__/Routing-test.js
@@ -39,7 +39,6 @@ describe('creating routes from ReactChildren', function () {
     var routes = [
       <Route handler={Static} path="/baz" />
     ]; 
-    debugger;
     Router.run(routes, '/bar', function (Handler, state) {
       var html = React.renderToString(<Handler/>);
       expect(html).toMatch(/Bar/);

--- a/modules/__tests__/Routing-test.js
+++ b/modules/__tests__/Routing-test.js
@@ -2,7 +2,7 @@ var expect = require('expect');
 var React = require('react');
 var Router = require('../index');
 var Route = require('../components/Route');
-var { Foo, Bar, Nested } = require('../utils/TestHandlers');
+var { Foo, Bar, Nested, Static } = require('../utils/TestHandlers');
 
 describe('creating routes from ReactChildren', function () {
   it('works with falsy children', function (done) {
@@ -34,4 +34,17 @@ describe('creating routes from ReactChildren', function () {
       done();
     });
   });
+
+  it('works with static routes', function (done) {
+    var routes = [
+      <Route handler={Static} path="/baz" />
+    ]; 
+    debugger;
+    Router.run(routes, '/bar', function (Handler, state) {
+      var html = React.renderToString(<Handler/>);
+      expect(html).toMatch(/Bar/);
+      done();
+    });
+  });
+
 });

--- a/modules/utils/TestHandlers.js
+++ b/modules/utils/TestHandlers.js
@@ -1,5 +1,6 @@
 var React = require('react');
 var RouteHandler = require('../components/RouteHandler');
+var Route = require('../components/Route');
 var State = require('../State');
 
 exports.Nested = React.createClass({
@@ -28,6 +29,24 @@ exports.Bar = React.createClass({
 exports.Baz = React.createClass({
   render: function () {
     return <div className="Baz">Baz</div>;
+  }
+});
+
+exports.Static = React.createClass({
+  statics: {
+    routes: [
+      <Route path="/bar" handler={exports.Bar}/>,
+      <Route path="/baz" handler={exports.Baz}/>
+    ]
+  },
+
+  render: function () {
+    return (
+      <div>
+        <h1 className="Static">Static</h1>
+        <RouteHandler />
+      </div>
+    );
   }
 });
 


### PR DESCRIPTION
I added the ability to define Routes in the static section of the handler so that each module can operate independently. I also added a test case which demonstrates the use. 

An example:

```
var App= React.createClass({
  statics: {
    routes: [
       <Route name="inbox" handler={Inbox}/>,
       <Route name="calendar" handler={Calendar}/>,
       <DefaultRoute handler={Dashboard}/>
    ]
  },

  render: function () {
    return (
      <div>
        <header>
          <ul>
            <li><Link to="app">Dashboard</Link></li>
            <li><Link to="inbox">Inbox</Link></li>
            <li><Link to="calendar">Calendar</Link></li>
          </ul>
          Logged in as Jane
        </header>

        {/* this is the important part */}
        <RouteHandler/>
      </div>
    );
  }
});

var routes = (
  <Route name="app" path="/" handler={App} />
);

Router.run(routes, function (Handler) {
  React.render(<Handler/>, document.body);
});
```

This allows App to exist entirely in its own space and not require any callers to know what its route structure is.
