### PR TITLE
[fixed] Allow special characters in query

### DIFF
--- a/modules/utils/Path.js
+++ b/modules/utils/Path.js
@@ -133,7 +133,7 @@ var Path = {
     var queryString = qs.stringify(query, { indices: false });
 
     if (queryString)
-      return Path.withoutQuery(path) + '?' + decodeURIComponent(queryString);
+      return Path.withoutQuery(path) + '?' + queryString;
 
     return path;
   },

--- a/modules/utils/__tests__/Path-test.js
+++ b/modules/utils/__tests__/Path-test.js
@@ -318,6 +318,10 @@ describe('Path.withQuery', function () {
   it('merges two query strings', function () {
     expect(Path.withQuery('/path?a=b', { c: [ 'd', 'e' ] })).toEqual('/path?a=b&c=d&c=e');
   });
+
+  it('handles special characters', function () {
+    expect(Path.withQuery('/path?a=b', { c: [ 'd#e', 'f&a=i#j+k' ] })).toEqual('/path?a=b&c=d%23e&c=f%26a%3Di%23j%2Bk');
+  });
 });
 
 describe('Path.normalize', function () {


### PR DESCRIPTION
Previously, special characters in query were left as is, potentially overwriting other query parameters and causing ambiguity.
Now, they are properly escaped.
Fixes #804.