### PR TITLE
[added] wraptag property for Link

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -15,7 +15,8 @@ function isModifiedEvent(event) {
 
 /**
  * <Link> components are used to create an <a> element that links to a route.
- * When that route is active, the link gets an "active" class name (or the
+ * You can also ask it to be wrapped in a tag by supplying a `wraptag` prop.
+ * When the route is active, the link gets an "active" class name (or the
  * value of its `activeClassName` prop).
  *
  * For example, assuming you have the following route:
@@ -42,7 +43,13 @@ var Link = React.createClass({
     to: PropTypes.string.isRequired,
     params: PropTypes.object,
     query: PropTypes.object,
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
+    wraptag: function(props){
+      var tag = props.wraptag;
+      if (tag && !React.DOM[tag]){
+        return new Error('Wraptag must be a valid DOM tag, but was "'+tag+'"!');
+      }
+    }
   },
 
   getDefaultProps: function () {
@@ -94,13 +101,14 @@ var Link = React.createClass({
   },
 
   render: function () {
+    var wraptag = this.props.wraptag;
     var props = assign({}, this.props, {
       href: this.getHref(),
-      className: this.getClassName(),
+      className: wraptag ? "" : this.getClassName(),
       onClick: this.handleClick
     });
-
-    return React.DOM.a(props, this.props.children);
+    var link = React.DOM.a(props, this.props.children);
+    return wraptag ? React.DOM[wraptag]({className: this.getClassName()},link) : link;
   }
 
 });

--- a/modules/components/__tests__/Link-test.js
+++ b/modules/components/__tests__/Link-test.js
@@ -10,6 +10,7 @@ var { Foo, Bar } = require('../../utils/TestHandlers');
 var { click } = React.addons.TestUtils.Simulate;
 
 describe('A Link', function () {
+
   describe('with params and a query', function () {
     it('knows how to make its href', function () {
       var LinkHandler = React.createClass({
@@ -91,6 +92,44 @@ describe('A Link', function () {
       Router.run(routes, TestLocation, function (Handler) {
         React.render(<Handler/>, div, () => {
           steps.shift()();
+        });
+      });
+    });
+  });
+
+  describe('when given a wraptag', function () {
+    it('renders inside that tag, and wraptag gets the classnames', function (done) {
+      var LinkHandler = React.createClass({
+        render: function () {
+          return (
+            <div>
+              <Link
+                to="foo"
+                className="dontKillMe"
+                activeClassName="highlight"
+                wraptag="li"
+              >Link</Link>
+              <RouteHandler/>
+            </div>
+          );
+        }
+      });
+
+      var routes = (
+        <Route path="/" handler={LinkHandler}>
+          <Route name="foo" handler={Foo} />
+        </Route>
+      );
+
+      var div = document.createElement('div');
+
+      TestLocation.history = ['/foo'];
+
+      Router.run(routes, TestLocation, function (Handler) {
+        React.render(<Handler/>, div, function(){
+          var li = div.querySelector('li');
+          expect(li.className.split(' ').sort().join(' ')).toEqual('dontKillMe highlight');
+          done();
         });
       });
     });


### PR DESCRIPTION
Since it is a [very](https://github.com/rackt/react-router/issues/760) [common](https://github.com/rackt/react-router/issues/666) [use case](https://github.com/rackt/react-router/issues/83) to want the `active` class of a `Link` to be applied to the parent tag for Bootstrap compatibility, this PR adds a new optional `wraptag` prop to `Link`. If supplied, the link will be wrapped in the given tag, and the class names applied to the wrapper instead of the anchor tag.

That means I can now do this:

```javascript
<Link to="foo" wraptag="li">Foo</Link>
```
instead of having to [make my own wrapper component](https://github.com/rackt/react-router/blob/master/docs/api/mixins/State.md#examples), looking something like this:

```javascript
var Navlink = React.createClass({
  mixins: [ State ],
  render: function() {
    var p = this.props;
    var className = (p.linkClasses || '')+(this.isActive(p.to, p.params, p.query) ? ' active' : '');
    return <li className={className}>{Link(p)}</li>;
  }
});
```

