### PR TITLE
[fixed] Use more correct children invariant

### DIFF
--- a/modules/Routing.js
+++ b/modules/Routing.js
@@ -89,7 +89,7 @@ function createRoute(element, parentRoute, namedRoutes) {
     );
 
     invariant(
-      props.children == null,
+      React.Children.count(props.children) === 0,
       '<NotFoundRoute> must not have children'
     );
 
@@ -111,7 +111,7 @@ function createRoute(element, parentRoute, namedRoutes) {
     );
 
     invariant(
-      props.children == null,
+      React.Children.count(props.children) === 0,
       '<DefaultRoute> must not have children'
     );
 


### PR DESCRIPTION
With the current implementation `<NotFoundRoute {...props}>{[]}</NotFoundRoute>` fails, but clearly there are no children. This uses a more accurate check to determine whether there are actually component children.