### PR TITLE
[added] Link activeStyle property

### DIFF
--- a/docs/api/components/Link.md
+++ b/docs/api/components/Link.md
@@ -36,8 +36,12 @@ your route handler with `this.getQuery()`.
 
 ### `activeClassName`
 
-The className a `Link` receives when it's route is active. Defaults to
+The className a `Link` receives when its route is active. Defaults to
 `active`.
+
+### `activeStyle`
+
+Object, the styles to apply to the link element when its route is active.
 
 ### `onClick`
 
@@ -67,5 +71,8 @@ active -->
 
 <!-- change the activeClassName -->
 <Link activeClassName="current" to="user" params={{userId: user.id}}>{user.name}</Link>
+
+<!-- change style when link is active -->
+<Link style={{color: 'white'}} activeStyle={{color: 'red'}} to="user" params={{userId: user.id}} query={{foo: bar}}>{user.name}</Link>
 ```
 

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -42,6 +42,7 @@ var Link = React.createClass({
     to: PropTypes.string.isRequired,
     params: PropTypes.object,
     query: PropTypes.object,
+    activeStyle: PropTypes.object,
     onClick: PropTypes.func
   },
 
@@ -87,10 +88,14 @@ var Link = React.createClass({
     if (this.props.className)
       classNames[this.props.className] = true;
 
-    if (this.isActive(this.props.to, this.props.params, this.props.query))
+    if (this.getActiveState())
       classNames[this.props.activeClassName] = true;
 
     return classSet(classNames);
+  },
+
+  getActiveState: function () {
+    return this.isActive(this.props.to, this.props.params, this.props.query);
   },
 
   render: function () {
@@ -99,6 +104,9 @@ var Link = React.createClass({
       className: this.getClassName(),
       onClick: this.handleClick
     });
+
+    if (props.activeStyle && this.getActiveState())
+      props.style = props.activeStyle;
 
     return React.DOM.a(props, this.props.children);
   }

--- a/modules/components/__tests__/Link-test.js
+++ b/modules/components/__tests__/Link-test.js
@@ -94,6 +94,65 @@ describe('A Link', function () {
         });
       });
     });
+
+    it('has applies activeStyle', function (done) {
+      var LinkHandler = React.createClass({
+        render: function () {
+          return (
+            <div>
+              <Link
+                to="foo"
+                style={{color: 'white'}}
+                activeStyle={{color: 'red'}}
+              >Link</Link>
+              <RouteHandler/>
+            </div>
+          );
+        }
+      });
+
+      var routes = (
+        <Route path="/" handler={LinkHandler}>
+          <Route name="foo" handler={Foo} />
+          <Route name="bar" handler={Bar} />
+        </Route>
+      );
+
+      var div = document.createElement('div');
+      TestLocation.history = ['/foo'];
+      var steps = [];
+
+      function assertActive () {
+        var a = div.querySelector('a');
+        expect(a.style.color).toEqual('red');
+      }
+
+      function assertInactive () {
+        var a = div.querySelector('a');
+        expect(a.style.color).toEqual('white');
+      }
+
+      steps.push(() => {
+        assertActive();
+        TestLocation.push('/bar');
+      });
+
+      steps.push(() => {
+        assertInactive();
+        TestLocation.push('/foo');
+      });
+
+      steps.push(() => {
+        assertActive();
+        done();
+      });
+
+      Router.run(routes, TestLocation, function (Handler) {
+        React.render(<Handler/>, div, () => {
+          steps.shift()();
+        });
+      });
+    });
   });
 
   describe('when clicked', function () {

--- a/modules/components/__tests__/Link-test.js
+++ b/modules/components/__tests__/Link-test.js
@@ -73,23 +73,23 @@ describe('A Link', function () {
         expect(a.className).toEqual('dontKillMe');
       }
 
-      steps.push(() => {
+      steps.push(function () {
         assertActive();
         TestLocation.push('/bar');
       });
 
-      steps.push(() => {
+      steps.push(function () {
         assertInactive();
         TestLocation.push('/foo');
       });
 
-      steps.push(() => {
+      steps.push(function () {
         assertActive();
         done();
       });
 
       Router.run(routes, TestLocation, function (Handler) {
-        React.render(<Handler/>, div, () => {
+        React.render(<Handler/>, div, function () {
           steps.shift()();
         });
       });
@@ -132,23 +132,23 @@ describe('A Link', function () {
         expect(a.style.color).toEqual('white');
       }
 
-      steps.push(() => {
+      steps.push(function () {
         assertActive();
         TestLocation.push('/bar');
       });
 
-      steps.push(() => {
+      steps.push(function () {
         assertInactive();
         TestLocation.push('/foo');
       });
 
-      steps.push(() => {
+      steps.push(function () {
         assertActive();
         done();
       });
 
       Router.run(routes, TestLocation, function (Handler) {
-        React.render(<Handler/>, div, () => {
+        React.render(<Handler/>, div, function () {
           steps.shift()();
         });
       });


### PR DESCRIPTION
If you are styling components in the component itself (not using external CSS), then active styling is not possible at the moment. This PR adds an optional `activeStyle` property to Link to allow for this scenario.

Super simple example:

```js

var style = {
  color: 'white',
  fontSize: 12,
  textDecoration: 'none'
};

var activeStyle = assign({}, style, {
  color: 'red'
});

<Link style={style} activeStyle={activeStyle} to="route">Link</Link>
```