### PR TITLE
Session history tracking

### DIFF
--- a/modules/Scrolling.js
+++ b/modules/Scrolling.js
@@ -30,23 +30,23 @@ var Scrolling = {
 
   statics: {
     /**
-     * Records curent scroll position as the last known position for the given URL path.
+     * Records curent scroll position as the last known position for the given key.
      */
-    recordScrollPosition: function (path) {
+    recordScrollPosition: function (key) {
       if (!this.scrollHistory)
         this.scrollHistory = {};
 
-      this.scrollHistory[path] = getWindowScrollPosition();
+      this.scrollHistory[key] = getWindowScrollPosition();
     },
 
     /**
-     * Returns the last known scroll position for the given URL path.
+     * Returns the last known scroll position for the given key.
      */
-    getScrollPosition: function (path) {
+    getScrollPosition: function (key) {
       if (!this.scrollHistory)
         this.scrollHistory = {};
 
-      return this.scrollHistory[path] || null;
+      return this.scrollHistory[key] || null;
     }
   },
 
@@ -73,7 +73,7 @@ var Scrolling = {
 
     if (scrollBehavior)
       scrollBehavior.updateScrollPosition(
-        this.constructor.getScrollPosition(this.state.path),
+        this.constructor.getScrollPosition(this.state.history ? this.state.history.key : this.state.path),
         this.state.action
       );
   }

--- a/modules/Session.js
+++ b/modules/Session.js
@@ -2,6 +2,10 @@
 function Session () {
 }
 
+Session.prototype.isValidState = function (state) {
+  return state && state.id && state.current;
+};
+
 Session.prototype.getState = function () {
   return {
     id: this._id,
@@ -15,15 +19,14 @@ Session.prototype.next = function () {
 };
 
 Session.prototype.setState = function (state) {
-  if (state && state.id && state.current) {
-    this._id = state.id;
-    this._current = parseInt(state.current);
-    return true;
-  } else {
-    this._id = Math.random().toString(36).substr(2, 9); // https://gist.github.com/gordonbrander/2230317
-    this._current = 1;
-    return false;
-  }
+  this._id = state.id;
+  this._current = parseInt(state.current);
+};
+
+Session.prototype.reset = function () {
+  this._id = Math.random().toString(36).substr(2, 9); // https://gist.github.com/gordonbrander/2230317
+  this._current = 1;
+  return this.getState();
 };
 
 

--- a/modules/Session.js
+++ b/modules/Session.js
@@ -1,0 +1,32 @@
+var assign = require('react/lib/Object.assign');
+var Path = require('./utils/Path');
+
+function Session () {
+}
+
+Session.prototype.getState = function () {
+  return {
+    id: this._id,
+    current: this._current
+  };
+};
+
+Session.prototype.next = function () {
+  this._current += 1;
+  return this.getState();
+};
+
+Session.prototype.setState = function (state) {
+  if (state && state.id && state.current) {
+    this._id = state.id;
+    this._current = parseInt(state.current);
+    return true;
+  } else {
+    this._id = Math.random().toString(36).substr(2, 9); // https://gist.github.com/gordonbrander/2230317
+    this._current = 1;
+    return false;
+  }
+};
+
+
+module.exports = Session;

--- a/modules/Session.js
+++ b/modules/Session.js
@@ -1,5 +1,3 @@
-var assign = require('react/lib/Object.assign');
-var Path = require('./utils/Path');
 
 function Session () {
 }

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -342,7 +342,7 @@ function createRouter(options) {
         // Record the scroll position as early as possible to
         // get it before browsers try update it automatically.
         if (prevPath && action === LocationActions.PUSH)
-          this.recordScrollPosition(prevPath);
+          this.recordScrollPosition(state.history ? state.history.key : prevPath);
 
         var match = this.match(path);
 

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -18,6 +18,7 @@ var Transition = require('./Transition');
 var PropTypes = require('./PropTypes');
 var Redirect = require('./Redirect');
 var History = require('./History');
+var Session = require('./Session');
 var Cancellation = require('./Cancellation');
 var supportsHistory = require('./utils/supportsHistory');
 var Path = require('./utils/Path');
@@ -133,6 +134,7 @@ function createRouter(options) {
   var nextState = {};
   var pendingTransition = null;
   var dispatchHandler = null;
+  var session = null;
 
   if (typeof location === 'string')
     location = new StaticLocation(location);
@@ -245,12 +247,13 @@ function createRouter(options) {
        */
       transitionTo: function (to, params, query) {
         var path = this.makePath(to, params, query);
+        var state = session && session.next();
 
         if (pendingTransition) {
           // Replace so pending location does not stay in history.
-          location.replace(path);
+          location.replace(path, state);
         } else {
-          location.push(path);
+          location.push(path, state);
         }
       },
 
@@ -259,7 +262,7 @@ function createRouter(options) {
        * the current URL in the history stack.
        */
       replaceWith: function (to, params, query) {
-        location.replace(this.makePath(to, params, query));
+        location.replace(this.makePath(to, params, query), session && session.getState());
       },
 
       /**
@@ -303,7 +306,12 @@ function createRouter(options) {
       },
 
       handleLocationChange: function (change) {
-        this.dispatch(change.path, change.type);
+        var sessionState = null;
+
+        if (session && session.setState(change.state))
+          sessionState = session.getState();
+
+        this.dispatch(change.path, change.type, sessionState);
       },
 
       /**
@@ -322,7 +330,7 @@ function createRouter(options) {
        * transition. To resolve asynchronously, they may use the callback argument. If no
        * hooks wait, the transition is fully synchronous.
        */
-      dispatch: function (path, action) {
+      dispatch: function (path, action, sessionState) {
         this.cancelPendingTransition();
 
         var prevPath = state.path;
@@ -382,6 +390,11 @@ function createRouter(options) {
             dispatchHandler.call(Router, error, transition, {
               path: path,
               action: action,
+              history: sessionState && {
+                id: sessionState.id,
+                current: sessionState.current,
+                key: sessionState.id + sessionState.current
+              },
               pathname: match.pathname,
               routes: nextRoutes,
               params: nextParams,
@@ -427,12 +440,19 @@ function createRouter(options) {
           this.isRunning = true;
         }
 
+        if (location.supportsState) {
+          session = new Session();
+          var success = session.setState(location.getCurrentState());
+          if (!success)
+            location.replaceState(session.getState(), true);
+        }
+
         // Bootstrap using the current path.
         this.refresh();
       },
 
       refresh: function () {
-        Router.dispatch(location.getCurrentPath(), null);
+        Router.dispatch(location.getCurrentPath(), null, session && session.getState());
       },
 
       stop: function () {

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -277,7 +277,8 @@ function createRouter(options) {
        * because we cannot reliably track history length.
        */
       goBack: function () {
-        if (History.length > 1 || location === RefreshLocation) {
+        var hasHistory = session ? session.getState().current > 1 : History.length > 1;
+        if (hasHistory || location === RefreshLocation) {
           location.pop();
           return true;
         }

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -307,12 +307,15 @@ function createRouter(options) {
       },
 
       handleLocationChange: function (change) {
-        var sessionState = null;
+        if (session) {
+          if (session.isValidState(change.state)) {
+            session.setState(change.state);
+          } else {
+            location.replaceState(session.getState(), true);
+          }
+        }
 
-        if (session && session.setState(change.state))
-          sessionState = session.getState();
-
-        this.dispatch(change.path, change.type, sessionState);
+        this.dispatch(change.path, change.type, session && session.getState());
       },
 
       /**
@@ -443,9 +446,14 @@ function createRouter(options) {
 
         if (location.supportsState) {
           session = new Session();
-          var success = session.setState(location.getCurrentState());
-          if (!success)
-            location.replaceState(session.getState(), true);
+          var state = location.getCurrentState();
+
+          if (session.isValidState(state)) {
+            session.setState(state);
+          } else {
+            state = session.reset();
+            location.replaceState(state, true);
+          }
         }
 
         // Bootstrap using the current path.

--- a/modules/index.js
+++ b/modules/index.js
@@ -10,6 +10,8 @@ exports.HistoryLocation = require('./locations/HistoryLocation');
 exports.RefreshLocation = require('./locations/RefreshLocation');
 exports.StaticLocation = require('./locations/StaticLocation');
 
+exports.addLocationState = require('./utils/addLocationState');
+
 exports.ImitateBrowserBehavior = require('./behaviors/ImitateBrowserBehavior');
 exports.ScrollToTopBehavior = require('./behaviors/ScrollToTopBehavior');
 

--- a/modules/locations/HistoryLocation.js
+++ b/modules/locations/HistoryLocation.js
@@ -16,7 +16,7 @@ function notifyChange(type, state) {
   var change = {
     path: getWindowPath(),
     type: type,
-    state: state || window.history.state
+    state: (typeof state  !== 'undefined') ? state : window.history.state
   };
 
   _changeListeners.forEach(function (listener) {
@@ -79,7 +79,11 @@ var HistoryLocation = {
   },
 
   replaceState: function (state, silent) {
-    window.history.replaceState(state, '', encodeURI(getWindowPath()));
+    var hash = window.location.href.split('#')[1];
+    hash = hash ? '#' + hash : '';
+
+    window.history.replaceState(state, '', encodeURI(getWindowPath() + hash));
+
     if (!silent) {
       notifyChange(LocationActions.REPLACE);
     }

--- a/modules/locations/HistoryLocation.js
+++ b/modules/locations/HistoryLocation.js
@@ -12,10 +12,11 @@ function getWindowPath() {
 
 var _changeListeners = [];
 
-function notifyChange(type) {
+function notifyChange(type, state) {
   var change = {
     path: getWindowPath(),
-    type: type
+    type: type,
+    state: state || window.history.state
   };
 
   _changeListeners.forEach(function (listener) {
@@ -25,14 +26,16 @@ function notifyChange(type) {
 
 var _isListening = false;
 
-function onPopState() {
-  notifyChange(LocationActions.POP);
+function onPopState (event) {
+  notifyChange(LocationActions.POP, event.state);
 }
 
 /**
  * A Location that uses HTML5 history.
  */
 var HistoryLocation = {
+
+  supportsState: true,
 
   addChangeListener: function (listener) {
     _changeListeners.push(listener);
@@ -64,20 +67,31 @@ var HistoryLocation = {
     }
   },
 
-  push: function (path) {
-    window.history.pushState({ path: path }, '', encodeURI(path));
+  push: function (path, state) {
+    window.history.pushState(state, '', encodeURI(path));
     History.length += 1;
     notifyChange(LocationActions.PUSH);
   },
 
-  replace: function (path) {
-    window.history.replaceState({ path: path }, '', encodeURI(path));
+  replace: function (path, state) {
+    window.history.replaceState(state, '', encodeURI(path));
     notifyChange(LocationActions.REPLACE);
+  },
+
+  replaceState: function (state, silent) {
+    window.history.replaceState(state, '', encodeURI(getWindowPath()));
+    if (!silent) {
+      notifyChange(LocationActions.REPLACE);
+    }
   },
 
   pop: History.back,
 
   getCurrentPath: getWindowPath,
+
+  getCurrentState: function () {
+    return window.history.state;
+  },
 
   toString: function () {
     return '<HistoryLocation>';

--- a/modules/utils/addLocationState.js
+++ b/modules/utils/addLocationState.js
@@ -1,0 +1,104 @@
+var assign = require('react/lib/Object.assign');
+var Path = require('./Path');
+
+function addLocationState (location) {
+
+  var _changeListeners = [];
+  var _isListening = false;
+  var _ignoreNext = false;
+
+  function withState (path, state) {
+    return Path.withQuery(path, {
+      _state: state
+    });
+  }
+
+  function withoutState (path) {
+    var query = Path.extractQuery(path);
+    if (!query) {
+      return path;
+    }
+
+    delete query._state;
+
+    return Path.withQuery(Path.withoutQuery(path), query);
+  }
+
+  function extractState (path) {
+    var query = Path.extractQuery(path);
+    return query && query._state;
+  }
+
+  function notifyChange (change) {
+    _changeListeners.forEach(function (listener) {
+      listener(change);
+    });
+  }
+
+  function onLocationChange (change) {
+    if (_ignoreNext) {
+      _ignoreNext = false;
+      return;
+    }
+
+    change.state = extractState(change.path);
+    change.path = withoutState(change.path);
+    notifyChange(change);
+  }
+
+
+  return assign({}, location, {
+
+    supportsState: true,
+
+    addChangeListener: function (listener) {
+      _changeListeners.push(listener);
+
+      if (!_isListening) {
+        location.addChangeListener && location.addChangeListener(onLocationChange);
+        _isListening = true;
+      }
+    },
+
+    removeChangeListener: function (listener) {
+      _changeListeners = _changeListeners.filter(function (l) {
+        return l !== listener;
+      });
+
+      if (_changeListeners.length === 0) {
+        location.removeChangeListener && location.removeChangeListener(onLocationChange);
+        _isListening = false;
+      }
+    },
+
+    getCurrentPath: function () {
+      return withoutState(location.getCurrentPath());
+    },
+
+    getCurrentState: function () {
+      return extractState(location.getCurrentPath());
+    },
+
+    push: function (path, state) {
+      location.push(withState(path, state));
+    },
+
+    replace: function (path, state) {
+      location.replace(withState(path, state));
+    },
+
+    replaceState: function (state, silent) {
+      if (silent === true)
+        _ignoreNext = true;
+
+      location.replace(withState(location.getCurrentPath(), state));
+    },
+
+    toString: function () {
+      return location.toString() + ' (with state)';
+    }
+
+  });
+}
+
+module.exports = addLocationState;

--- a/modules/utils/addLocationState.js
+++ b/modules/utils/addLocationState.js
@@ -55,7 +55,9 @@ function addLocationState (location) {
       _changeListeners.push(listener);
 
       if (!_isListening) {
-        location.addChangeListener && location.addChangeListener(onLocationChange);
+        if (location.addChangeListener)
+          location.addChangeListener(onLocationChange);
+
         _isListening = true;
       }
     },
@@ -66,7 +68,9 @@ function addLocationState (location) {
       });
 
       if (_changeListeners.length === 0) {
-        location.removeChangeListener && location.removeChangeListener(onLocationChange);
+        if (location.removeChangeListener)
+          location.removeChangeListener(onLocationChange);
+
         _isListening = false;
       }
     },
@@ -88,7 +92,7 @@ function addLocationState (location) {
     },
 
     replaceState: function (state, silent) {
-      if (silent === true)
+      if (silent)
         _ignoreNext = true;
 
       location.replace(withState(location.getCurrentPath(), state));


### PR DESCRIPTION
(Work in progress) 

This PR makes the router more aware of the current session history by managing a counter and an id that's stored inside history.state. Before every push, the counter is incremented, and on every location change, it is reloaded from the active state (or reset). The (random) id is used to distinguish between two "sessions" within the same browser tab.

Since only `HistoryLocation` supports state, I also added `utils/addLocationState.js` which can be used to wrap other locations to attach state to the query (for local development, or environments without url bar). Not sure if it's worth having though.

The history state is currently exposed via `state.history`:
* `state.history.current`: index of currently active session entry (1-based)
* `state.history.id`: random string id for current "session"; each id has its own series of entries
* `state.history.key`: key for caching based on active entry in browser tab (concatenation of the two above, for convenience)

Use cases:
* more reliable `goBack()` check (already implemented), perhaps also `goForward()` and `go(n)`
* scroll position can be saved by history entry, not just by path (already implemented)
* persisting arbitrary data based on browser session entry (e.g. form data)
* basis for more advanced navigation (#767), such as going back or forward to when a route was last visited
* animations based on navigation direction (back vs forward), or even pages that were traversed

Seems to be related to #828.