### PR TITLE
[added] router.runSync(path)

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -1202,6 +1202,17 @@ describe('Router.run', function () {
   });
 });
 
+describe('Router#runSync', function () {
+  it('returns {Handler, state} for a given URL path', function () {
+    var routes = <Route handler={Foo} path="/foo"/>;
+    var router = Router.create(routes);
+    var {Handler, state} = router.runSync('/foo');
+    var html = React.renderToString(<Handler/>);
+    expect(html).toMatch(/Foo/);
+    expect(state.path).toEqual('/foo');
+  });
+});
+
 describe.skip('unmounting', function () {
   afterEach(function () {
     window.location.hash = '';

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -1202,14 +1202,29 @@ describe('Router.run', function () {
   });
 });
 
-describe('Router#runSync', function () {
-  it('returns {Handler, state} for a given URL path', function () {
-    var routes = <Route handler={Foo} path="/foo"/>;
-    var router = Router.create(routes);
-    var {Handler, state} = router.runSync('/foo');
-    var html = React.renderToString(<Handler/>);
-    expect(html).toMatch(/Foo/);
-    expect(state.path).toEqual('/foo');
+describe('router.run', function () {
+  describe('with both a path and a callback argument', function () {
+    it('respects the path and calls the callback', function (done) {
+      var routes = <Route handler={Foo} path="/foo"/>;
+      var router = Router.create(routes);
+      router.run('/foo', function(Handler, state) {
+        var html = React.renderToString(<Handler/>);
+        expect(html).toMatch(/Foo/);
+        expect(state.path).toEqual('/foo');
+        done();
+      });
+    });
+  });
+
+  describe('with only a path argument', function () {
+    it('returns a {Handler, state} object for the given URL path', function () {
+      var routes = <Route handler={Foo} path="/foo"/>;
+      var router = Router.create(routes);
+      var {Handler, state} = router.run('/foo');
+      var html = React.renderToString(<Handler/>);
+      expect(html).toMatch(/Foo/);
+      expect(state.path).toEqual('/foo');
+    });
   });
 });
 

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -389,6 +389,36 @@ function createRouter(options) {
         this.refresh();
       },
 
+      /**
+       * Starts this router and returns {Handler, state} for a given URL path.
+       *
+       * This is the synchronous version of `run`, useful in server environments
+       * that are able to evaluate JavaScript but have no notion of callbacks.
+       */
+      runSync: function (path) {
+        var match = this.match(path);
+
+        warning(
+          match != null,
+          'No route matches path "%s". Make sure you have <Route path="%s"> somewhere in your routes',
+          path, path
+        );
+
+        if (match == null)
+          match = {};
+
+        nextState = {
+          path: path,
+          action: null,
+          pathname: match.pathname,
+          routes: match.routes || [],
+          params: match.params || {},
+          query: match.query || {}
+        };
+
+        return { Handler: Router, state: nextState };
+      },
+
       refresh: function () {
         Router.dispatch(location.getCurrentPath(), null);
       },

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -356,67 +356,68 @@ function createRouter(options) {
        * the callback is called only once. Otherwise, the location should be one of the
        * Router.*Location objects (e.g. Router.HashLocation or Router.HistoryLocation).
        */
-      run: function (callback) {
+      run: function (path, callback) {
+        if (typeof path === 'function') {
+          callback = path;
+        }
+
         invariant(
           !this.isRunning,
           'Router is already running'
         );
 
-        dispatchHandler = function (error, transition, newState) {
-          if (error)
-            Router.handleError(error);
+        if (callback) {
+          dispatchHandler = function (error, transition, newState) {
+            if (error)
+              Router.handleError(error);
 
-          if (pendingTransition !== transition)
-            return;
+            if (pendingTransition !== transition)
+              return;
 
-          pendingTransition = null;
+            pendingTransition = null;
 
-          if (transition.abortReason) {
-            Router.handleAbort(transition.abortReason);
-          } else {
-            callback.call(this, this, nextState = newState);
+            if (transition.abortReason) {
+              Router.handleAbort(transition.abortReason);
+            } else {
+              callback.call(this, this, nextState = newState);
+            }
+          };
+
+          if (typeof path === 'string')
+            location = new StaticLocation(path);
+
+          if (!(location instanceof StaticLocation)) {
+            if (location.addChangeListener)
+              location.addChangeListener(Router.handleLocationChange);
+
+            this.isRunning = true;
           }
-        };
 
-        if (!(location instanceof StaticLocation)) {
-          if (location.addChangeListener)
-            location.addChangeListener(Router.handleLocationChange);
+          // Bootstrap using the current path.
+          this.refresh();
+        } else {
+          var match = this.match(path);
 
-          this.isRunning = true;
+          warning(
+            match != null,
+            'No route matches path "%s". Make sure you have <Route path="%s"> somewhere in your routes',
+            path, path
+          );
+
+          if (match == null)
+            match = {};
+
+          nextState = {
+            path: path,
+            action: null,
+            pathname: match.pathname,
+            routes: match.routes || [],
+            params: match.params || {},
+            query: match.query || {}
+          };
+
+          return { Handler: Router, state: nextState };
         }
-
-        // Bootstrap using the current path.
-        this.refresh();
-      },
-
-      /**
-       * Starts this router and returns {Handler, state} for a given URL path.
-       *
-       * This is the synchronous version of `run`, useful in server environments
-       * that are able to evaluate JavaScript but have no notion of callbacks.
-       */
-      runSync: function (path) {
-        var match = this.match(path);
-
-        warning(
-          match != null,
-          'No route matches path "%s". Make sure you have <Route path="%s"> somewhere in your routes',
-          path, path
-        );
-
-        if (match == null)
-          match = {};
-
-        nextState = {
-          path: path,
-          action: null,
-          pathname: match.pathname,
-          routes: match.routes || [],
-          params: match.params || {},
-          query: match.query || {}
-        };
-
-        return { Handler: Router, state: nextState };
       },
 
       refresh: function () {


### PR DESCRIPTION
This implements the synchronous version of `router.run()`, useful in server environments that are able to evaluate JavaScript but have no notion of callbacks (e.g. [ExecJS](https://github.com/sstephenson/execjs)).

Naturally, this is also usable within Node.js. Here's an example:

```jsx
var routes = <Route handler={Foo} path="/foo"/>;
var router = Router.create(routes);

express().get(/.*/, function(req, res, next) {
  var {Handler, state} = router.runSync(req.path);
  // do something interesting with `state` object
  res.send(React.renderToString(<Handler />));
});
```