### PR TITLE
Let us try out react 0.13!

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "karma-sourcemap-loader": "^0.3.2",
     "karma-webpack": "^1.3.1",
     "mocha": "^2.0.1",
-    "react": "0.12.x",
+    "react": ">= 0.12.0",
     "rf-changelog": "^0.4.0",
     "rx": "2.3.18",
     "webpack": "^1.4.13",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "karma-sourcemap-loader": "^0.3.2",
     "karma-webpack": "^1.3.1",
     "mocha": "^2.0.1",
-    "react": ">= 0.12.0",
+    "react": ">=0.12.0",
     "rf-changelog": "^0.4.0",
     "rx": "2.3.18",
     "webpack": "^1.4.13",


### PR DESCRIPTION
I am trying to do my due diligence on checking for compat issues with the new version but since the peer dependancy range for the router is `0.12.x` I can't install `0.13.x` rc or otherwise. I would be great if the range here was more permissive, even if it comes with a "buyer beware" warning. Alternatively we could just pin to the current and next version, since React tends to be pretty good on upgrading to the next from the last most recent: `>=0.12.0 < 0.14.0`