### PR TITLE
Improve React 0.13 compatibility

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -81,7 +81,7 @@ class Link extends React.Component {
     var props = assign({}, this.props, {
       href: this.getHref(),
       className: this.getClassName(),
-      onClick: this.handleClick
+      onClick: this.handleClick.bind(this)
     });
 
     if (props.activeStyle && this.getActiveState())

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -423,7 +423,7 @@ function createRouter(options) {
 
         if (!(location instanceof StaticLocation)) {
           if (location.addChangeListener)
-            location.addChangeListener(Router.handleLocationChange);
+            location.addChangeListener(Router.handleLocationChange.bind(Router));
 
           this.isRunning = true;
         }
@@ -440,7 +440,7 @@ function createRouter(options) {
         this.cancelPendingTransition();
 
         if (location.removeChangeListener)
-          location.removeChangeListener(Router.handleLocationChange);
+          location.removeChangeListener(Router.handleLocationChange.bind(Router));
 
         this.isRunning = false;
       },


### PR DESCRIPTION
This pull request fixes two things:
* When changing routes, `Router.dispatch` gets correctly called and does not throw an error. (An issue I raised in #638 )
* Link click handlers are not correctly bound and don't throw an error when called

I haven't touched the rest and there are still some tests that are failing.