### PR TITLE
fixed animation example, use this.context

### DIFF
--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -1,14 +1,14 @@
-// TODO: animations aren't happening, not sure what the problem is
 var React = require('react');
 var TransitionGroup = require('react/lib/ReactCSSTransitionGroup');
 var Router = require('react-router');
 var { Route, RouteHandler, Link } = Router;
 
 var App = React.createClass({
-  mixins: [ Router.State ],
-
+  contextTypes: {
+    router: React.PropTypes.any.isRequired
+  },
   render: function () {
-    var name = this.getRoutes().reverse()[0].name;
+    var name = this.context.router.getCurrentPath();
 
     return (
       <div>
@@ -48,8 +48,8 @@ var Page2 = React.createClass({
 
 var routes = (
   <Route handler={App}>
-    <Route name="page1" handler={Page1} addHandlerKey={true} />
-    <Route name="page2" handler={Page2} addHandlerKey={true} />
+    <Route name="page1" handler={Page1} />
+    <Route name="page2" handler={Page2} />
   </Route>
 );
 


### PR DESCRIPTION
This uses the new `this.context.router`, and specifically uses `.getCurrentPath()` which is 95% of the time what uniquely identifies the page.

Questions:
 - should it be using contextTypes, or the mixin?
 - should it directly require `react-router/modules/PropTypes` to get `PropTypes.router`, or use `.any`?

I'm not sure what addHandlerKey does, but it works without it, and we're setting a key ourselves anyway.