### PR TITLE
Use `Router` instead of `this` now that autobinding is off

### DIFF
--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -173,9 +173,9 @@ function createRouter(options) {
       },
 
       clearAllRoutes: function () {
-        this.cancelPendingTransition();
-        this.namedRoutes = {};
-        this.routes = [];
+        Router.cancelPendingTransition();
+        Router.namedRoutes = {};
+        Router.routes = [];
       },
 
       /**
@@ -185,18 +185,18 @@ function createRouter(options) {
         if (isReactChildren(routes))
           routes = createRoutesFromReactChildren(routes);
 
-        addRoutesToNamedRoutes(routes, this.namedRoutes);
+        addRoutesToNamedRoutes(routes, Router.namedRoutes);
 
-        this.routes.push.apply(this.routes, routes);
+        Router.routes.push.apply(Router.routes, routes);
       },
 
       /**
        * Replaces routes of this router from the given children object (see ReactChildren).
        */
       replaceRoutes: function (routes) {
-        this.clearAllRoutes();
-        this.addRoutes(routes);
-        this.refresh();
+        Router.clearAllRoutes();
+        Router.addRoutes(routes);
+        Router.refresh();
       },
 
       /**
@@ -205,7 +205,7 @@ function createRouter(options) {
        * match can be made.
        */
       match: function (path) {
-        return Match.findMatch(this.routes, path);
+        return Match.findMatch(Router.routes, path);
       },
 
       /**
@@ -217,7 +217,7 @@ function createRouter(options) {
         if (PathUtils.isAbsolute(to)) {
           path = to;
         } else {
-          var route = (to instanceof Route) ? to : this.namedRoutes[to];
+          var route = (to instanceof Route) ? to : Router.namedRoutes[to];
 
           invariant(
             route instanceof Route,
@@ -236,7 +236,7 @@ function createRouter(options) {
        * to the route with the given name, URL parameters, and query.
        */
       makeHref: function (to, params, query) {
-        var path = this.makePath(to, params, query);
+        var path = Router.makePath(to, params, query);
         return (location === HashLocation) ? '#' + path : path;
       },
 
@@ -245,7 +245,7 @@ function createRouter(options) {
        * a new URL onto the history stack.
        */
       transitionTo: function (to, params, query) {
-        var path = this.makePath(to, params, query);
+        var path = Router.makePath(to, params, query);
 
         if (pendingTransition) {
           // Replace so pending location does not stay in history.
@@ -260,7 +260,7 @@ function createRouter(options) {
        * the current URL in the history stack.
        */
       replaceWith: function (to, params, query) {
-        location.replace(this.makePath(to, params, query));
+        location.replace(Router.makePath(to, params, query));
       },
 
       /**
@@ -292,7 +292,7 @@ function createRouter(options) {
         if (abortReason instanceof Cancellation) {
           return;
         } else if (abortReason instanceof Redirect) {
-          location.replace(this.makePath(abortReason.to, abortReason.params, abortReason.query));
+          location.replace(Router.makePath(abortReason.to, abortReason.params, abortReason.query));
         } else {
           location.pop();
         }
@@ -304,7 +304,7 @@ function createRouter(options) {
       },
 
       handleLocationChange: function (change) {
-        this.dispatch(change.path, change.type);
+        Router.dispatch(change.path, change.type);
       },
 
       /**
@@ -324,7 +324,7 @@ function createRouter(options) {
        * hooks wait, the transition is fully synchronous.
        */
       dispatch: function (path, action) {
-        this.cancelPendingTransition();
+        Router.cancelPendingTransition();
 
         var prevPath = state.path;
         var isRefreshing = action == null;
@@ -335,9 +335,9 @@ function createRouter(options) {
         // Record the scroll position as early as possible to
         // get it before browsers try update it automatically.
         if (prevPath && action === LocationActions.PUSH)
-          this.recordScrollPosition(prevPath);
+          Router.recordScrollPosition(prevPath);
 
-        var match = this.match(path);
+        var match = Router.match(path);
 
         warning(
           match != null,
@@ -370,7 +370,7 @@ function createRouter(options) {
           toRoutes = nextRoutes;
         }
 
-        var transition = new Transition(path, this.replaceWith.bind(this, path));
+        var transition = new Transition(path, Router.replaceWith.bind(Router, path));
         pendingTransition = transition;
 
         var fromComponents = mountedComponents.slice(prevRoutes.length - fromRoutes.length);
@@ -401,7 +401,7 @@ function createRouter(options) {
        */
       run: function (callback) {
         invariant(
-          !this.isRunning,
+          !Router.isRunning,
           'Router is already running'
         );
 
@@ -417,19 +417,19 @@ function createRouter(options) {
           if (transition.abortReason) {
             Router.handleAbort(transition.abortReason);
           } else {
-            callback.call(this, this, nextState = newState);
+            callback.call(Router, Router, nextState = newState);
           }
         };
 
         if (!(location instanceof StaticLocation)) {
           if (location.addChangeListener)
-            location.addChangeListener(Router.handleLocationChange.bind(Router));
+            location.addChangeListener(Router.handleLocationChange);
 
-          this.isRunning = true;
+          Router.isRunning = true;
         }
 
         // Bootstrap using the current path.
-        this.refresh();
+        Router.refresh();
       },
 
       refresh: function () {
@@ -437,12 +437,12 @@ function createRouter(options) {
       },
 
       stop: function () {
-        this.cancelPendingTransition();
+        Router.cancelPendingTransition();
 
         if (location.removeChangeListener)
-          location.removeChangeListener(Router.handleLocationChange.bind(Router));
+          location.removeChangeListener(Router.handleLocationChange);
 
-        this.isRunning = false;
+        Router.isRunning = false;
       },
 
       getLocation: function () {


### PR DESCRIPTION
Inspired by [this comment](https://github.com/rackt/react-router/commit/47ca64c6c1615d5a1330f002af861dafdd1a167f#commitcomment-10037061) by @tgriesser, I changed `this` to `Router` inside router's static methods.

If we take this change, we will avoid binding because we already know the context and don't need it.

Another benefit is making source more easy to follow. When I just started contributing, I kept getting confused what `this` means in a particular method, until I realized most action happens in statics. This change makes it obvious.

I made these edits on Github so they're not tested. What do you think? @mjackson 

Note: **this change fixes an actual mistake** introduced [here](https://github.com/rackt/react-router/commit/47ca64c6c1615d5a1330f002af861dafdd1a167f#commitcomment-10037061). It is intended to prevent similar mistakes from happening in the future.