### PR TITLE
Filtered routes by criteria

### DIFF
--- a/docs/api/components/Route.md
+++ b/docs/api/components/Route.md
@@ -36,6 +36,12 @@ If you specify `ignoreScrollBehavior` attribute on a route, changes in `params` 
 
 Note that changes in `query` never adjust scroll position, regardless of the value of this attribute.
 
+### `criteria`
+
+An object of strings or RegExps whose keys must match against the values set by
+`Router.setGlobalCriteria(object)`. This can be used for filtering routes based
+on hostname, enabled feature branches, or other global flags.
+
 Example
 -------
 

--- a/docs/guides/path-matching.md
+++ b/docs/guides/path-matching.md
@@ -101,3 +101,28 @@ path: *
 matches everything, but you probably want `<NotFoundRoute/>`
 ```
 
+
+Matching Global Criteria
+------------------------
+
+Setting a global criteria (`Router.setGlobalCriteria(object)`) filters all routes
+against an optional `criteria` property on each route. This can be used for
+filtering routes based on hostname, enabled feature branches, or other global
+flag.
+
+Examples
+--------
+
+
+Routes.jsx
+```
+<Route criteria={ { host: /^auth\./ } }>
+  <Route name="register" handler={ RegisterRoute } />
+  <Route name="login" handler={ LoginRoute } />
+  <!-- matches LoginRoute when 'host' starts with 'auth.' -->
+  <DefaultRoute handler={ LoginRoute } />
+</Route>
+<Route name="home" path="/" handler={ DashboardRoute } />
+<!-- matches DashboardRoute when host does not match -->
+<DefaultRoute handler={ DashboardRoute } />
+```

--- a/modules/Match.js
+++ b/modules/Match.js
@@ -2,6 +2,10 @@
 var PathUtils = require('./PathUtils');
 
 function deepSearch(route, pathname, query) {
+  // Check this route path meets the set criteria (if any)
+  if (!route.meetsCriteria())
+    return null;
+
   // Check the subtree first to find the most deeply-nested match.
   var childRoutes = route.childRoutes;
   if (childRoutes) {

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -1197,3 +1197,103 @@ describe('Router.run', function () {
     });
   });
 });
+
+describe('Router.setGlobalCriteria', function () {
+
+  describe('when filtering by regexp', function () {
+    var routes;
+    beforeEach(function () {
+      routes = [
+        <Route path="/" handler={Nested} criteria={ { match: /^filtered\./ } }>
+          <Route path="users" handler={Foo} />
+        </Route>,
+        <Route path="/" handler={Nested}>
+          <Route path="users" handler={Baz} />
+        </Route>
+      ];
+      Router.setGlobalCriteria({ match: 'filtered.string' });
+    });
+
+    it('returns nested route', function (done) {
+      Router.run(routes, '/users', function (Handler, state) {
+        var html = React.renderToString(<Handler />);
+        expect(html).toMatch(/Nested/);
+        expect(html).toMatch(/Foo/);
+        done();
+      });
+    });
+  });
+
+  describe('when filtering by equality', function () {
+    var routes;
+    beforeEach(function () {
+      routes = [
+        <Route path="/" handler={Nested} criteria={ { match: 'filtered.string' } }>
+          <Route path="users" handler={Foo} />
+        </Route>,
+        <Route path="/" handler={Nested}>
+          <Route path="users" handler={Baz} />
+        </Route>
+      ];
+      Router.setGlobalCriteria({ match: 'filtered.string' });
+    });
+
+    it('returns nested route', function (done) {
+      Router.run(routes, '/users', function (Handler, state) {
+        var html = React.renderToString(<Handler/>);
+        expect(html).toMatch(/Nested/);
+        expect(html).toMatch(/Foo/);
+        done();
+      });
+    });
+  });
+
+  describe('when filtering does not match regexp', function () {
+    var routes;
+    beforeEach(function () {
+      routes = [
+        <Route path="/" handler={Nested} criteria={ { match: /^filtered\./ } }>
+          <Route path="users" handler={Foo}  />
+        </Route>,
+        <Route path="/" handler={Nested}>
+          <Route path="users" handler={Baz} />
+        </Route>
+      ];
+      Router.setGlobalCriteria({ match: 'some.other.string' });
+    });
+
+    it('returns nested route', function (done) {
+      Router.run(routes, '/users', function (Handler, state) {
+        var html = React.renderToString(<Handler/>);
+        expect(html).toMatch(/Nested/);
+        expect(html).toMatch(/Baz/);
+        done();
+      });
+    });
+  });
+
+  describe('when filtering does not match equality', function () {
+    var routes;
+    beforeEach(function () {
+      routes = [
+        <Route path="/" handler={Nested} criteria={ { match: 'filtered.string' } }>
+          <Route path="users" handler={Foo} />
+        </Route>,
+        <Route path="/" handler={Nested}>
+          <Route path="users" handler={Baz} />
+        </Route>
+      ];
+      Router.setGlobalCriteria({ match: 'some.other.string' });
+    });
+
+    it('returns nested route', function (done) {
+      Router.run(routes, '/users', function (Handler, state) {
+        var html = React.renderToString(<Handler/>);
+        expect(html).toMatch(/Nested/);
+        expect(html).toMatch(/Baz/);
+        done();
+      });
+    });
+  });
+
+});

--- a/modules/index.js
+++ b/modules/index.js
@@ -22,6 +22,7 @@ exports.createRoute = require('./Route').createRoute;
 exports.createDefaultRoute = require('./Route').createDefaultRoute;
 exports.createNotFoundRoute = require('./Route').createNotFoundRoute;
 exports.createRedirect = require('./Route').createRedirect;
+exports.setGlobalCriteria = require('./Route').setGlobalCriteria;
 exports.createRoutesFromReactChildren = require('./createRoutesFromReactChildren');
 exports.create = require('./createRouter');
 exports.run = require('./runRouter');


### PR DESCRIPTION
We have a rapidly growing React application which renders on both the server- and client-sides. Some sections of the app are on separate subdomains. The app uses the same views/assets/code across many subdomains, so we control it all through one runtime. This mean react-router needs to be able to distinguish which host or subdomain it's on to render the appropriate routes. This PR adds two features to the API: 

[`<Route criteria />`](https://github.com/careerlounge/react-router/blob/33af5b9c388aad697fb9b9b00cf9c1d96b11b382/docs/api/components/Route.md#criteria): criteria is an object of key: values. value can either be a RegExp or primitive type which will be compared against the same key set by `setGlobalCriteria`. If it matches, it will be considered as a route match. If criteria is not set, it automatically matches. 

The syntax can be a mouthful (`<Route criteria={ { host: /^auth\./ } } />`) but is most flexible. Alternate syntax such as `<Route match-host={ /\.auth/ } />` (ala `data-` attributes) could be considered.

[`Router.setGlobalCriteria(object)`](https://github.com/careerlounge/react-router/blob/33af5b9c388aad697fb9b9b00cf9c1d96b11b382/docs/guides/path-matching.md#matching-global-criteria) sets the criteria, updating each object[key] with _globalCriteria[key]. Criteria is stored statically, as I don't suppose people use multiple Routers on one page.