### PR TITLE
[fixed] broken async example

### DIFF
--- a/examples/async-data/app.js
+++ b/examples/async-data/app.js
@@ -112,7 +112,7 @@ var Index = React.createClass({
 });
 
 var routes = (
-  <Route handler={App}>
+  <Route name="contacts" path="/" handler={App}>
     <DefaultRoute name="index" handler={Index}/>
     <Route name="contact" path="contact/:id" handler={Contact}/>
   </Route>


### PR DESCRIPTION
Async example would crash at [/examples/async-data/app.js#L64](https://github.com/rackt/react-router/blob/master/examples/async-data/app.js#L64). Mentioned at [Issue 897](https://github.com/rackt/react-router/issues/897)