### PR TITLE
Minor fix in example: remove unused argument

### DIFF
--- a/examples/master-detail/app.js
+++ b/examples/master-detail/app.js
@@ -70,8 +70,8 @@ var Contact = React.createClass({
 
   mixins: [ Router.Navigation, Router.State ],
 
-  getStateFromStore: function (id) {
-    id = this.getParams().id;
+  getStateFromStore: function () {
+    var id = this.getParams().id;
     return {
       contact: ContactStore.getContact(id)
     };


### PR DESCRIPTION
It is immediately assigned from getParams() and so clearly is an unused argument. Moreover other functions do not call it with an argument.