### PR TITLE
Empty query string ("/?") causes route match to fail

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -5,7 +5,7 @@ var qs = require('qs');
 var paramCompileMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|[*.()\[\]\\+|{}^$]/g;
 var paramInjectMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$?]*[?]?)|[*]/g;
 var paramInjectTrailingSlashMatcher = /\/\/\?|\/\?\/|\/\?/g;
-var queryMatcher = /\?(.+)/;
+var queryMatcher = /\?(.*)$/;
 
 var _compiledPatterns = {};
 

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -648,6 +648,15 @@ describe('Router', function () {
       });
     });
 
+    it('renders with empty query string', function (done) {
+      var routes = <Route handler={Foo} path='/'/>;
+      Router.run(routes, '/?', function (Handler, state) {
+        var html = React.renderToString(<Handler />);
+        expect(html).toMatch(/Foo/);
+        done();
+      });
+    });
+
     it('executes transition hooks when only the query changes', function (done) {
       var fromKnifeCalled = false;
       var fromSpoonCalled = false;


### PR DESCRIPTION
`/` and `/?a` route to the same place, but `/?` won't match any route and will trigger not found. This issue is not experienced with `HistoryLocation` in the browser because when the URL ends with `?` then `window.location.search == ""` thereby dropping the question mark; however when using `req.url` in Node.js the `?` is not automatically dropped.

I've fixed the issue via a tweak to the regex, and added a relevant test.

I'm not sure if we need to change `extractQuery` in PathUtils to return false if `match[1].length === 0`?