### PR TITLE
0.13 [change] Switch react classSet with classnames package

### DIFF
--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var classSet = require('react/lib/cx');
+var classSet = require('classnames');
 var assign = require('react/lib/Object.assign');
 var PropTypes = require('../PropTypes');
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-core": "^4.4.6",
     "babel-loader": "^4.0.0",
     "bundle-loader": "^0.5.2",
+    "classnames": "^1.1.4",
     "events": "1.0.2",
     "expect": "^1.1.0",
     "jsxhint": "^0.8.1",
@@ -43,7 +44,8 @@
     "webpack-dev-server": "^1.6.6"
   },
   "peerDependencies": {
-    "react": "0.13.0-rc1"
+    "react": "0.13.0-rc1",
+    "classnames": "^1.1.4"
   },
   "dependencies": {
     "qs": "2.3.3"


### PR DESCRIPTION
From what I've read, it looks like [`classnames`](https://github.com/JedWatson/classnames) is the new replacement for `classSet`. This PR makes that change to eliminate the deprecation warning.