### PR TITLE
fix Path.withQuery

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -1,5 +1,5 @@
 var invariant = require('react/lib/invariant');
-var merge = require('qs/lib/utils').merge;
+var objectAssign = require('object-assign');
 var qs = require('qs');
 
 var paramCompileMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|[*.()\[\]\\+|{}^$]/g;
@@ -144,14 +144,14 @@ var PathUtils = {
     var existingQuery = PathUtils.extractQuery(path);
 
     if (existingQuery)
-      query = query ? merge(existingQuery, query) : existingQuery;
+      query = query ? objectAssign(existingQuery, query) : existingQuery;
 
     var queryString = qs.stringify(query, { indices: false });
 
     if (queryString)
       return PathUtils.withoutQuery(path) + '?' + queryString;
 
-    return path;
+    return Path.withoutQuery(path);
   }
 
 };

--- a/modules/__tests__/PathUtils-test.js
+++ b/modules/__tests__/PathUtils-test.js
@@ -319,6 +319,10 @@ describe('PathUtils.withQuery', function () {
     expect(PathUtils.withQuery('/path?a=b', { c: [ 'd', 'e' ] })).toEqual('/path?a=b&c=d&c=e');
   });
 
+  it('removes query string', function () {
+    expect(Path.withQuery('/a/b/c?a=b', { a: undefined })).toEqual('/a/b/c');
+  });
+
   it('handles special characters', function () {
     expect(PathUtils.withQuery('/path?a=b', { c: [ 'd#e', 'f&a=i#j+k' ] })).toEqual('/path?a=b&c=d%23e&c=f%26a%3Di%23j%2Bk');
   });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "0.12.x"
   },
   "dependencies": {
+    "object-assign": "^2.0.0",
     "qs": "2.3.3"
   },
   "tags": [


### PR DESCRIPTION
This commit fixes two bugs in Path.withQuery:

  1. Strip of the query if the new one is empty (added a test).
  2. use object-assign instead of qs/lib/utils/merge.
     (see https://github.com/hapijs/qs/issues/67)

Thanks for the awesome project!

Cheers,
Max