### PR TITLE
fixed the owner/parent warning issue

### DIFF
--- a/modules/components/RouteHandler.js
+++ b/modules/components/RouteHandler.js
@@ -12,8 +12,12 @@ class RouteHandler extends React.Component {
 
   getChildContext() {
     return {
-      routeHandlers: this.context.routeHandlers.concat([ this ])
+      routeHandlers: this._routeHandlers
     };
+  }
+
+  componentWillMount() {
+    this._routeHandlers = this.context.routeHandlers.concat([ this ]);
   }
 
   componentDidMount() {
@@ -42,7 +46,7 @@ class RouteHandler extends React.Component {
   }
 
   render() {
-    return this.createChildRouteHandler();
+    return React.createElement('div', null, this.createChildRouteHandler());
   }
 
 }

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -524,13 +524,17 @@ function createRouter(options) {
 
     getChildContext: function () {
       return {
-        routeHandlers: [ this ],
+        routeHandlers: this._routeHandlers,
         router: Router
       };
     },
 
     getInitialState: function () {
       return (state = nextState);
+    },
+
+    componentWillMount: function() {
+      this._routeHandlers = [ this ];
     },
 
     componentWillReceiveProps: function () {


### PR DESCRIPTION
the warning had actually two causes: 

- the fact that the array was created in `getChildContext` which was called twice to perform the check. keeping a reference to it solves this
- the fact that the `RouteHandler` component didn't wrap its handler with an element