### PR TITLE
fix transition.redirect() with Router.HashLocation

### DIFF
--- a/modules/locations/HashLocation.js
+++ b/modules/locations/HashLocation.js
@@ -36,8 +36,9 @@ function onHashChange() {
     // changed. It was probably caused by the user clicking the Back
     // button, but may have also been the Forward button or manual
     // manipulation. So just guess 'pop'.
-    notifyChange(_actionType || LocationActions.POP);
+    var curActionType = _actionType;
     _actionType = null;
+    notifyChange(curActionType || LocationActions.POP);
   }
 }
 


### PR DESCRIPTION
This commit fixes https://github.com/rackt/react-router/issues/958 

Using HashLocation, the _actionType was lost on **transition.redirect** due to multiple async onHashChange calls for push and replace, which made the redirect wrongly trigger a **pop** state.

regards,
mario