### PR TITLE
Cleanup CSS in Animation Example

### DIFF
--- a/examples/animations/app.css
+++ b/examples/animations/app.css
@@ -1,8 +1,4 @@
 .Image {
-  position: relative;
-}
-
-.Image {
   position: absolute;
   height: 400px;
   width: 400px;

--- a/examples/animations/app.css
+++ b/examples/animations/app.css
@@ -4,8 +4,8 @@
 
 .Image {
   position: absolute;
-  height: 400;
-  width: 400;
+  height: 400px;
+  width: 400px;
 }
 
 .example-enter {


### PR DESCRIPTION
This is a tiny little patch to clean up the CSS on the animation example. It adds `px` to width and height properties so that the values are actually applied to the HTML display, and removes a duplicate class declaration for `.Image` which was being overridden. 