### PR TITLE
HashLocation should encodeURI in ensureSlash

### DIFF
--- a/modules/locations/HashLocation.js
+++ b/modules/locations/HashLocation.js
@@ -25,7 +25,7 @@ function ensureSlash() {
   if (path.charAt(0) === '/')
     return true;
 
-  HashLocation.replace('/' + path);
+  HashLocation.replace('/' + encodeURI(path));
 
   return false;
 }

--- a/modules/locations/__tests__/HashLocation-test.js
+++ b/modules/locations/__tests__/HashLocation-test.js
@@ -42,4 +42,23 @@ describe('HashLocation.getCurrentPath', function () {
     expect(HashLocation.getCurrentPath())
         .toBe('complicated+string/full%2Fof%3Fspecial%chars%20and%23escapesሴ');
   });
+
+});
+
+describe('HashLocation.ensureSlash', function () {
+  it('re-encodes the path before replacing it', function() {
+      var changeListener = function() {};
+
+      HashLocation.push('no leading slash');
+
+      HashLocation.addChangeListener(changeListener);
+      HashLocation.removeChangeListener(changeListener);
+
+      expect(HashLocation.getCurrentPath())
+          .toBe('/no leading slash');
+
+      expect(window.location.href.split('#')[1])
+          .toBe('/no%20leading%20slash');
+
+  });
 });


### PR DESCRIPTION
It decodes the path before operating on it, it should `encodeURI` before replacing it.

Without this change any URL that includes a properly encodes space (`%20`) gets converted to a space if the URL doesn't have a leading slash.