### PR TITLE
[added] Router.runSync

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -1197,3 +1197,24 @@ describe('Router.run', function () {
     });
   });
 });
+
+describe('Router.runSync', function () {
+
+  it('returns Handler and state synchronously', function () {
+    var routes = <Route path="/" handler={EchoFooProp} />;
+    var { Handler, state } = Router.runSync(routes, '/');
+    var html = React.renderToString(<Handler foo="bar"/>);
+    expect(html).toMatch(/bar/);
+    expect(state).toBeAn(Object);
+  });
+
+  describe('when there is an async transition hook', function () {
+    it('throws an error', function () {
+      var routes = <Route path="/" handler={Async} />;
+
+      expect(function () {
+        Router.runSync(routes, '/');
+      }).toThrow(/is async/);
+    });
+  });
+});

--- a/modules/index.js
+++ b/modules/index.js
@@ -25,4 +25,5 @@ exports.createRedirect = require('./Route').createRedirect;
 exports.createRoutesFromReactChildren = require('./createRoutesFromReactChildren');
 exports.create = require('./createRouter');
 exports.run = require('./runRouter');
+exports.runSync = require('./runRouterSync');
 

--- a/modules/runRouterSync.js
+++ b/modules/runRouterSync.js
@@ -1,0 +1,47 @@
+var runRouter = require('./runRouter');
+var invariant = require('react/lib/invariant');
+
+/**
+ * A high-level convenience method that creates, configures, and
+ * runs a router synchonously in one shot. The method signature is:
+ *
+ *   { Handler, state } = Router.runSync(routes[, location ]);
+ *
+ * Using the current URL path on the server-side:
+ *
+ *   { Handler } = Router.runSync(routes, req.path);
+ *   React.render(<Handler/>, document.body);
+ *
+ * Using `window.location.hash` to manage the URL, you could do:
+ *
+ *   { Handler } = Router.runSync(routes);
+ *   React.render(<Handler/>, document.body);
+ *
+ * Using HTML5 history and a custom "cursor" prop:
+ *
+ *   { Handler } = Router.runSync(routes, Router.HistoryLocation);
+ *   React.render(<Handler cursor={cursor}/>, document.body);
+ *
+ * Note: In contrast to Router.run, this method acts on the
+ * assumption that all routing is fully synchronous, which is
+ * usually the case. The sole exception to this are route handlers
+ * with transition hooks taking a callback that is asynchronously
+ * invoked when transitioning. On the server-side, this affects
+ * only willTransitionTo (with a callback argument).
+ */
+function runRouterSync(routes, location) {
+  var result = null;
+
+  runRouter(routes, location, function(Handler, state) {
+    result = { Handler: Handler, state: state };
+  });
+
+  invariant(
+    result,
+    'You cannot use "runSync" when your transition hook is async'
+  );
+
+  return result;
+}
+
+module.exports = runRouterSync;


### PR DESCRIPTION
`Router.runSync` is a high-level convenience method that creates, configures, and runs a router synchonously in one shot. The method signature is:

```js
{ Handler, state } = Router.runSync(routes[, location ]);
```

Using the current URL path on the server-side:

```jsx
{ Handler } = Router.runSync(routes, req.path);
React.render(<Handler/>, document.body);
```

Using `window.location.hash` to manage the URL, you could do:

```jsx
{ Handler } = Router.runSync(routes);
React.render(<Handler/>, document.body);
```

Using HTML5 history and a custom "cursor" prop:

```js
{ Handler } = Router.runSync(routes, Router.HistoryLocation);
React.render(<Handler cursor={cursor}/>, document.body);
```

**Note:** In contrast to `Router.run`, this method acts on the assumption that all routing is fully synchronous, which is usually the case. The sole exception to this are route handlers with transition hooks taking a callback that is asynchronously invoked when transitioning. On the server-side, this affects only `willTransitionTo` (with a callback argument).

---

This obsoletes pull request #848. I've created this new one to make a clean cut. Compared to the old one, none of the existing code has changed; only additions were made.