### PR TITLE
Correct method names in RouterContext docs

### DIFF
--- a/docs/api/RouterContext.md
+++ b/docs/api/RouterContext.md
@@ -71,19 +71,19 @@ Creates an `href` to a route.
 this.context.router.makeHref('user', {userId: 123}); // "users/123"
 ```
 
-### `getPath()`
+### `getCurrentPath()`
 
 Returns the current URL path, including query string.
 
-### `getPathname()`
+### `getCurrentPathname()`
 
 Returns the current URL path without the query string.
 
-### `getParams()`
+### `getCurrentParams()`
 
 Returns a hash of the currently active URL params.
 
-### `getQuery()`
+### `getCurrentQuery()`
 
 Returns a hash of the currently active query params.
 
@@ -92,7 +92,7 @@ Returns a hash of the currently active query params.
 Returns `true` if a route, params, and query are active, `false`
 otherwise.
 
-### `getRoutes()`
+### `getCurrentRoutes()`
 
 Returns an array of the currently active routes, in nesting order.
 
@@ -108,7 +108,7 @@ Often you'll want access to params and query:
 // handler
 var User = React.createClass({
   render: function () {
-    var name = this.context.router.getParams().name;
+    var name = this.context.router.getCurrentParams().name;
     return (
       <div>
         <h1>{name}</h1>


### PR DESCRIPTION
Tried using the context methods based on the documentation, and they didn't appear to be defined.

Looked at the implementation of the now-deprecated State mixin (thanks for the high quality warnings!) to see what context methods correspond to the older mixin methods:
https://github.com/rackt/react-router/blob/master/modules/State.js

These updated method names seem to work in my app.

Thanks!
Jonathan