### PR TITLE
[added] router.goBackOrTransitionTo()

### DIFF
--- a/docs/api/RouterContext.md
+++ b/docs/api/RouterContext.md
@@ -55,6 +55,10 @@ if (!this.context.router.goBack()) {
 }
 ```
 
+### `goBackOrTransitionTo(routeNameOrPath, [params[, query]])`
+
+This is a convenience method for the use case shown in the preceding example.
+
 ### `makePath(routeName, params, query)`
 
 Creates a URL path to a route.

--- a/docs/guides/flux.md
+++ b/docs/guides/flux.md
@@ -80,8 +80,12 @@ To avoid this, you can do one of three things:
       },
 
       goBack() {
-        router.goBack();
+        return router.goBack();
       },
+
+      goBackOrTransitionTo() {
+        router.goBackOrTransitionTo.apply(router, arguments);
+      }
 
       run(render) {
         router.run(render);
@@ -122,7 +126,7 @@ Router.run(routes, (Handler, state) => {
 });
 ```
 
-Let `RouterStore` keep router state and add a public method to obtain it.  
+Let `RouterStore` keep router state and add a public method to obtain it.
 This way your action creators and other stores can learn about current router state.
 
 Handling route changes as actions

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -71,6 +71,7 @@ var stubRouterContext = (Component, props, stubs) => {
           transitionTo () {},
           replaceWith () {},
           goBack () {},
+          goBackOrTransitionTo () {},
           getCurrentPath () {},
           getCurrentRoutes () {},
           getCurrentPathname () {},

--- a/modules/__tests__/History-test.js
+++ b/modules/__tests__/History-test.js
@@ -11,6 +11,46 @@ describe('History', function () {
     it('has length 1', function () {
       expect(History.length).toEqual(1);
     });
+
+    describe('calling goBack()', function () {
+      it('returns false', function () {
+        var routes = <Route name="foo" handler={Foo}/>;
+        var location = new TestLocation([ '/foo' ]);
+        var router = Router.run(routes, location, function (Handler) { });
+        var consoleWarn = console.warn;
+        var emittedWarning;
+
+        console.warn = function(message) { emittedWarning = message; };
+
+        expect(router.goBack()).toBe(false);
+        expect(emittedWarning).toMatch(/no router history/);
+
+        console.warn = consoleWarn;
+      });
+    });
+
+    describe('calling goBackOrTransitionTo(route)', function () {
+      it('transitions to the specified route', function (done) {
+        var location = new TestLocation([ '/foo' ]);
+        var routes = [
+          <Route name="foo" handler={Foo}/>,
+          <Route name="about" handler={Foo}/>
+        ];
+
+        var count = 0;
+
+        var router = Router.run(routes, location, function (Handler, state) {
+          count += 1;
+
+          if (count === 2) {
+            expect(state.path).toEqual('/about');
+            done();
+          }
+        });
+
+        router.goBackOrTransitionTo('about');
+      });
+    });
   });
 
   describe('after navigating to a route', function () {
@@ -53,6 +93,61 @@ describe('History', function () {
 
           if (count === 2) {
             expect(History.length).toEqual(2);
+            done();
+          }
+        });
+
+        router.transitionTo('about');
+      });
+    });
+
+    describe('calling goBack()', function () {
+      it('transitions to the previous route', function (done) {
+        var routes = [
+          <Route name="foo" handler={Foo}/>,
+          <Route name="about" handler={Foo}/>
+        ];
+
+        var count = 0;
+
+        var router = Router.run(routes, location, function (Handler, state) {
+          count += 1;
+
+          if (count === 2) {
+            expect(state.path).toEqual('/about');
+            expect(router.goBack()).toBe(true);
+          }
+
+          if (count === 3) {
+            expect(state.path).toEqual('/foo');
+            done();
+          }
+        });
+
+        router.transitionTo('about');
+      });
+    });
+
+    describe('calling goBackOrTransitionTo()', function () {
+      it('transitions to the previous route', function (done) {
+        var routes = [
+          <Route name="foo" handler={Foo}/>,
+          <Route name="about" handler={Foo}/>,
+          <Route name="other" handler={Foo}/>
+        ];
+
+        var count = 0;
+
+        var router = Router.run(routes, location, function (Handler, state) {
+          count += 1;
+
+          if (count === 2) {
+            expect(state.path).toEqual('/about');
+            router.goBackOrTransitionTo('other');
+          }
+
+          if (count === 3) {
+            expect(state.path).toEqual('/foo');
             done();
           }
         });

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -274,15 +274,25 @@ function createRouter(options) {
        * don't support HTML5 history) this method will *always* send the client back
        * because we cannot reliably track history length.
        */
-      goBack: function () {
+      goBack: function (suppressWarning = false) {
         if (History.length > 1 || location === RefreshLocation) {
           location.pop();
           return true;
         }
 
-        warning(false, 'goBack() was ignored because there is no router history');
+        warning(suppressWarning, 'goBack() was ignored because there is no router history');
 
         return false;
+      },
+
+      /**
+       * Transitions to the previous URL if one is available, otherwise transitions
+       * to the URL specified in the arguments.
+       */
+      goBackOrTransitionTo: function () {
+        if (!Router.goBack(true)) {
+          Router.transitionTo.apply(Router, arguments);
+        }
       },
 
       handleAbort: options.onAbort || function (abortReason) {


### PR DESCRIPTION
This is a convenience method that implements the use case provided as the last example in the api doc for the `goBack()` function:

```js
if (!this.context.router.goBack()) {
  this.context.router.transitionTo('/otherpage')
}
```

This PR also adds some missing tests for `goBack` itself.