### PR TITLE
Transition hooks error handling

### DIFF
--- a/modules/Transition.js
+++ b/modules/Transition.js
@@ -35,14 +35,17 @@ Transition.from = function (transition, routes, components, callback) {
       if (error || transition.abortReason) {
         callback(error);
       } else if (route.onLeave) {
-        try {
+        if (route.onLeave.length > 2) {
           route.onLeave(transition, components[index], callback);
-
-          // If there is no callback in the argument list, call it automatically.
-          if (route.onLeave.length < 3)
-            callback();
-        } catch (e) {
-          callback(e);
+        } else {
+          // Catch errors if there is no callback in the argument list.
+          var err = null;
+          try {
+            route.onLeave(transition, components[index]);
+          } catch (e) {
+            err = e;
+          }
+          callback(err);
         }
       } else {
         callback();
@@ -57,14 +60,17 @@ Transition.to = function (transition, routes, params, query, callback) {
       if (error || transition.abortReason) {
         callback(error);
       } else if (route.onEnter) {
-        try {
+        if (route.onEnter.length > 3) {
           route.onEnter(transition, params, query, callback);
-
-          // If there is no callback in the argument list, call it automatically.
-          if (route.onEnter.length < 4)
-            callback();
-        } catch (e) {
-          callback(e);
+        } else {
+          // Catch errors if there is no callback in the argument list.
+          var err = null;
+          try {
+            route.onEnter(transition, params, query);
+          } catch (e) {
+            err = e;
+          }
+          callback(err);
         }
       } else {
         callback();


### PR DESCRIPTION
Currently, when a transition hook is defined, we invoke the callbacks within a try-catch block. Since everything after that is synchronous, throwing within router.run or during render will cause the error to be caught inside the transition handling, calling the callback a second time, and ultimately Router.handleError.

I changed it so that the callback is never called twice, and only synchronous transition hooks are contained within the try-catch block.

I'm not absolutely sure if this the right way though. We could also 

* not catch any errors at all (aside from the errors passed via callback)
* catch (synchronous) errors even if callback is in arguments list. But then we'd have to wait for the hook to finish execution before continuing, i.e. buffer synchronous callback invocations. Otherwise, calling callback synchronously would again lead to the problem this PR tries to solve. 

This would (mostly) fix #946, although I think there's another (browser) issue when it comes to reporting rethrown errors.