### PR TITLE
- Removed tags caused by Git

### DIFF
--- a/docs/api/RouterContext.md
+++ b/docs/api/RouterContext.md
@@ -136,11 +136,7 @@ Often you'll want access to params and query:
 // handler
 var User = React.createClass({
   contextTypes: {
-<<<<<<< HEAD
     router: React.PropTypes.func.isRequired
-=======
-    router: React.PropTypes.func
->>>>>>> update docs to show how to get access to context
   },
 
   render: function () {
@@ -187,11 +183,7 @@ Some navigation:
 ```js
 React.createClass({
   contextTypes: {
-<<<<<<< HEAD
     router: React.PropTypes.func.isRequired
-=======
-    router: React.PropTypes.func
->>>>>>> update docs to show how to get access to context
   },
 
   render: function() {


### PR DESCRIPTION
While browsing the documentation for the new feature utilizing React's Context I saw that the documentation included tags usually added by Git when merge conflicts were encountered. This PR should fix those.