### PR TITLE
DON'T MERGE: Router on props

### DIFF
--- a/modules/components/RouteHandler.js
+++ b/modules/components/RouteHandler.js
@@ -38,8 +38,9 @@ class RouteHandler extends React.Component {
   }
 
   createChildRouteHandler(props) {
-    var route = this.context.router.getRouteAtDepth(this.getRouteDepth());
-    return route ? React.createElement(route.handler, assign({}, props || this.props, { ref: REF_NAME })) : null;
+    var router = this.context.router;
+    var route = router.getRouteAtDepth(this.getRouteDepth());
+    return route ? React.createElement(route.handler, assign({}, props || this.props, { ref: REF_NAME }, {router})) : null;
   }
 
   render() {

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -21,6 +21,7 @@ var Match = require('./Match');
 var Route = require('./Route');
 var supportsHistory = require('./supportsHistory');
 var PathUtils = require('./PathUtils');
+var assign = require('object-assign');
 
 /**
  * The default location for new routers.
@@ -543,7 +544,7 @@ function createRouter(options) {
 
     render: function () {
       var route = Router.getRouteAtDepth(0);
-      return route ? React.createElement(route.handler, this.props) : null;
+      return route ? React.createElement(route.handler, assign({}, this.props, {router: Router})) : null;
     }
 
   });


### PR DESCRIPTION
@mjackson @gaearon 

I'm happy to use context to provide some clean APIs for people, but I'm not comfortable with everybody needing to use `contextTypes` in user code.

This puts the router on `props` of handlers so people can access it w/o any extra work. I'll write some tests and merge if I can get a thumbs up from one of you.