### PR TITLE
[fixed] "Something is calling a React component directly" warning

### DIFF
--- a/modules/State.js
+++ b/modules/State.js
@@ -26,7 +26,7 @@ function deprecatedMethod(routerMethodName, fn) {
  *       if (this.isActive('about'))
  *         className += ' is-active';
  *   
- *       return React.DOM.a({ className: className }, this.props.children);
+ *       return React.createElement('a', { className: className }, this.props.children);
  *     }
  *   });
  */

--- a/modules/components/Link.js
+++ b/modules/components/Link.js
@@ -83,7 +83,7 @@ class Link extends React.Component {
     if (props.activeStyle && this.getActiveState())
       props.style = props.activeStyle;
 
-    return React.DOM.a(props, this.props.children);
+    return React.createElement('a', props, this.props.children);
   }
 
 }


### PR DESCRIPTION
Use `React.createElement()` in `Link`'s `render()` instead