### PR TITLE
[DOCS FIX] correct object type for childContextTypes on the testing guide

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -60,7 +60,7 @@ Copy/paste this helper into your test utils to make things a bit easier:
 var stubRouterContext = (Component, props, stubs) => {
   return React.createClass({
     childContextTypes: {
-      router: object
+      router: React.PropTypes.object
     },
 
     getChildContext () {


### PR DESCRIPTION
I think it was a typo, just I got stuck for a while figuring it out, so I'm sending this to help future viewers.

By the way, when I use this I'm getting this warning: Warning: Failed Context Types: Invalid context `router` of type `object` supplied to `Link`, expected `function`. Check the render method of `TrainingGroupTile`. So I guess the childContextType did changed? Maybe this document needs more updates?