### PR TITLE
Router state getters (`router.getCurrent*`) expose internal state values to mutation

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -6,6 +6,7 @@ var RouteHandler = require('../components/RouteHandler');
 var TestLocation = require('../locations/TestLocation');
 var ScrollToTopBehavior = require('../behaviors/ScrollToTopBehavior');
 var getWindowScrollPosition = require('../getWindowScrollPosition');
+var PropTypes = require('../PropTypes');
 
 var {
   Foo,
@@ -1202,6 +1203,76 @@ describe('Router.run', function () {
 
         location.replace('/search/whatever');
         expect(didUpdateScroll).toBe(false);
+      });
+    });
+  });
+});
+
+describe('Router Context', function () {
+  function createAssertionHandler(assertions) {
+    return React.createClass({
+      contextTypes: {
+        router: PropTypes.router.isRequired
+      },
+      render: function () {
+        assertions.call(this, this.props, this.context);
+        return null;
+      }
+    });
+  }
+
+  describe('getCurrentParams', function () {
+
+    it('always returns a new copy', function (done) {
+      var routes = <Route
+        path='/:bar'
+        handler={createAssertionHandler(function (props, context) {
+          var router = context.router;
+          expect(router.getCurrentParams()).toNotBe(router.getCurrentParams());
+        })}
+      />;
+      Router.run(routes, '/baz', function (Handler) {
+        React.render(<Handler/>, document.createElement('div'), function () {
+          done();
+        });
+      });
+    });
+  });
+
+  describe('getCurrentQuery', function () {
+
+    it('always returns a new copy', function (done) {
+      var routes = <Route
+        path='/'
+        handler={createAssertionHandler(function (props, context) {
+          var router = context.router;
+          expect(router.getCurrentQuery()).toNotBe(router.getCurrentQuery());
+        })}
+      />;
+      Router.run(routes, '/?bar=baz', function (Handler) {
+        React.render(<Handler/>, document.createElement('div'), function () {
+          done();
+        });
+      });
+    });
+  });
+
+  describe('getCurrentRoutes', function () {
+
+    it('always returns a new copy', function (done) {
+      var routes = <Route>
+        <Route
+          path='/'
+          handler={createAssertionHandler(function (props, context) {
+            var router = context.router;
+            expect(router.getCurrentRoutes()).toNotBe(router.getCurrentRoutes());
+          })}
+        />
+      </Route>;
+      Router.run(routes, '/?bar=baz', function (Handler) {
+        React.render(<Handler/>, document.createElement('div'), function () {
+          done();
+        });
       });
     });
   });

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -2,6 +2,7 @@
 var React = require('react');
 var warning = require('react/lib/warning');
 var invariant = require('react/lib/invariant');
+var assign = require('react/lib/Object.assign');
 var canUseDOM = require('react/lib/ExecutionEnvironment').canUseDOM;
 var LocationActions = require('./actions/LocationActions');
 var ImitateBrowserBehavior = require('./behaviors/ImitateBrowserBehavior');
@@ -480,21 +481,21 @@ function createRouter(options) {
        * Returns an object of the currently active URL parameters.
        */
       getCurrentParams: function () {
-        return state.params;
+        return assign({}, state.params);
       },
 
       /**
        * Returns an object of the currently active query parameters.
        */
       getCurrentQuery: function () {
-        return state.query;
+        return assign({}, state.query);
       },
 
       /**
        * Returns an array of the currently active routes.
        */
       getCurrentRoutes: function () {
-        return state.routes;
+        return state.routes.slice(0);
       },
 
       /**


### PR DESCRIPTION
This usage is arguably a corner case, and there are plenty of ways of working around it (some of which are maybe better and more idiomatic), but the resulting bug from this usage was unexpected to me.

Given the following contrived example component:
```javascript
class SomeComponent extends React.Component {
  render() {
    const leafRoute = this.context.router.getCurrentRoutes().pop();
    // ... does some leafRoute-dependent something-or-other
  }
}
```

When another component in the same render cycle happens to want router state:
```javascript
class SomeOtherComponent extends React.Component {
  render() {
    const matchedRouteCount = this.context.router.getCurrentRoutes().length;
    console.log(matchedRouteCount);  // Uh oh, this is now n - 1, thanks to SomeComponent!
  }
}
```

This PR includes a new suite of simple tests for demonstrating the problem, as well as a naive solution.

There might be a simpler way of testing this, as well as a more robust way of solving it. I'm happy to update the PR to meet either (or both!) of these ideals.