### PR TITLE
Dispatch even if path has not changed & normalize Locations

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -87,11 +87,11 @@ describe('Router', function () {
             location.pop();
             expect(div.innerHTML).toMatch(/Bar/);
           }, Async.delay / 2);
+        });
 
-          setTimeout(function () {
-            expect(div.innerHTML).toMatch(/Bar/);
-            done();
-          }, Async.delay + 10);
+        steps.push(function () {
+          expect(div.innerHTML).toMatch(/Bar/);
+          done();
         });
 
         router = Router.create({
@@ -314,11 +314,11 @@ describe('Router', function () {
             location.pop();
             expect(div.innerHTML).toMatch(/Bar/);
           }, RedirectToFooAsync.delay / 2);
+        });
 
-          setTimeout(function () {
-            expect(div.innerHTML).toMatch(/Bar/);
-            done();
-          }, RedirectToFooAsync.delay + 10);
+        steps.push(function () {
+          expect(div.innerHTML).toMatch(/Bar/);
+          done();
         });
 
         router = Router.create({
@@ -421,9 +421,14 @@ describe('Router', function () {
 
         var div = document.createElement('div');
 
+        var runCount = 0;
         Router.run(routes, location, function (Handler) {
+          runCount += 1;
           React.render(<Handler/>, div, function () {
-            location.push('/abort');
+            if (runCount === 1){
+              location.push('/abort');
+              return;
+            }
             expect(div.innerHTML).toMatch(/Foo/);
             expect(location.getCurrentPath()).toEqual('/foo');
             done();
@@ -482,11 +487,11 @@ describe('Router', function () {
             location.pop();
             expect(div.innerHTML).toMatch(/Bar/);
           }, Async.delay / 2);
+        });
 
-          setTimeout(function () {
-            expect(div.innerHTML).toMatch(/Bar/);
-            done();
-          }, Async.delay + 10);
+        steps.push(function () {
+          expect(div.innerHTML).toMatch(/Bar/);
+          done();
         });
 
         router = Router.create({
@@ -741,7 +746,8 @@ describe('Router', function () {
 
       Router.run(routes, location, function (Handler, state) {
         React.render(<Handler/>, div, function () {
-          location.push('/baz');
+          if (state.path !== '/baz')
+            location.push('/baz');
         });
       });
     });

--- a/modules/actions/LocationActions.js
+++ b/modules/actions/LocationActions.js
@@ -16,7 +16,12 @@ var LocationActions = {
   /**
    * Indicates the most recent entry should be removed from the history stack.
    */
-  POP: 'pop'
+  POP: 'pop',
+
+  /**
+   * Indicates the current location should be refreshed.
+   */
+  REFRESH: 'refresh'
 
 };
 

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -327,10 +327,6 @@ function createRouter(options) {
         Router.cancelPendingTransition();
 
         var prevPath = state.path;
-        var isRefreshing = action == null;
-
-        if (prevPath === path && !isRefreshing)
-          return; // Nothing to do!
 
         // Record the scroll position as early as possible to
         // get it before browsers try update it automatically.

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -429,7 +429,7 @@ function createRouter(options) {
       },
 
       refresh: function () {
-        Router.dispatch(location.getCurrentPath(), null);
+        Router.dispatch(location.getCurrentPath(), LocationActions.REFRESH);
       },
 
       stop: function () {

--- a/modules/locations/HashLocation.js
+++ b/modules/locations/HashLocation.js
@@ -42,6 +42,11 @@ function onHashChange() {
   }
 }
 
+function refresh() {
+  _actionType = LocationActions.REFRESH;
+  onHashChange();
+}
+
 /**
  * A Location that uses `window.location.hash`.
  */
@@ -81,15 +86,25 @@ var HashLocation = {
   },
 
   push(path) {
-    _actionType = LocationActions.PUSH;
-    window.location.hash = path;
+    // ensure change event if path has not changed
+    if (path !== HashLocation.getCurrentPath()) {
+      _actionType = LocationActions.PUSH;
+      window.location.hash = path;
+    } else {
+      refresh();
+    }
   },
 
   replace(path) {
-    _actionType = LocationActions.REPLACE;
-    window.location.replace(
-      window.location.pathname + window.location.search + '#' + path
-    );
+    // ensure change event if path has not changed
+    if (path !== HashLocation.getCurrentPath()) {
+      _actionType = LocationActions.REPLACE;
+      window.location.replace(
+        window.location.pathname + window.location.search + '#' + path
+      );
+    } else {
+      refresh();
+    }
   },
 
   pop() {

--- a/modules/locations/HistoryLocation.js
+++ b/modules/locations/HistoryLocation.js
@@ -58,14 +58,24 @@ var HistoryLocation = {
   },
 
   push(path) {
-    window.history.pushState({ path: path }, '', path);
-    History.length += 1;
-    notifyChange(LocationActions.PUSH);
+    // don't push state if path has not changed
+    if (path !== HistoryLocation.getCurrentPath()) {
+      window.history.pushState({ path: path }, '', path);
+      History.length += 1;
+      notifyChange(LocationActions.PUSH);
+    } else {
+      notifyChange(LocationActions.REFRESH);
+    }
   },
 
   replace(path) {
-    window.history.replaceState({ path: path }, '', path);
-    notifyChange(LocationActions.REPLACE);
+    // don't replace state if path has not changed
+    if (path !== HistoryLocation.getCurrentPath()) {
+      window.history.replaceState({ path: path }, '', path);
+      notifyChange(LocationActions.REPLACE);
+    } else {
+      notifyChange(LocationActions.REFRESH);
+    }
   },
 
   pop: History.back,

--- a/modules/locations/TestLocation.js
+++ b/modules/locations/TestLocation.js
@@ -42,9 +42,13 @@ class TestLocation {
   }
 
   push(path) {
-    this.history.push(path);
-    this._updateHistoryLength();
-    this._notifyChange(LocationActions.PUSH);
+    if (!this.history.length || path !== this.getCurrentPath()) {
+      this.history.push(path);
+      this._updateHistoryLength();
+      this._notifyChange(LocationActions.PUSH);
+    } else {
+      this._notifyChange(LocationActions.REFRESH);
+    }
   }
 
   replace(path) {
@@ -53,9 +57,13 @@ class TestLocation {
       'You cannot replace the current path with no history'
     );
 
-    this.history[this.history.length - 1] = path;
+    if (path !== this.getCurrentPath()) {
+      this.history[this.history.length - 1] = path;
+      this._notifyChange(LocationActions.REPLACE);
+    } else {
+      this._notifyChange(LocationActions.REFRESH);
+    }
 
-    this._notifyChange(LocationActions.REPLACE);
   }
 
   pop() {


### PR DESCRIPTION
This PR does two things:

1. Always dispatch even if the path is the same as the one that was rendered last. 
2. Normalize behavior of Location push/replace in order to 
   * not create an additional history entry if path has not changed (HistoryLocation and TestLocation)
   * trigger refresh (new LocationAction type) even if path has not changed (currently HashLocation just ignores those)

For 1), I needed to update some tests to avoid recursion loops and adapt to the new behavior of causing more dispatches.

For 2), it would have also been possible to implement that in `Router.transitionTo/replaceWith`. I opted for changing the locations because the changes actually handle two different problems as outlined above. So it seems more logical to me to normalize them this way, instead of having the router work around those discrepancies.

Notes:

* this will make it so that aborting a transition will cause the previously rendered route to be refreshed
* edge case for HashLocation: using browser navigation to go back or forward (multiple steps) to the same path that's currently active will not trigger a refresh, since this won't trigger the hashchange event

Fixes #826 and #1027 

Would be great if someone could look over this :)