### PR TITLE
Use CSSTransitionGroup from React.addons

### DIFF
--- a/examples/animations/app.js
+++ b/examples/animations/app.js
@@ -1,5 +1,5 @@
-var React = require('react');
-var TransitionGroup = require('react/lib/ReactCSSTransitionGroup');
+var React = require('react/addons');
+var TransitionGroup = React.addons.CSSTransitionGroup;
 var Router = require('react-router');
 var { Route, RouteHandler, Link } = Router;
 


### PR DESCRIPTION
Including ReactCSSTransitionGroup directly from react/lib/ReactCSSTransitionGroup causes intermittent bugs which prevent enter animations from behaving properly in some cases.