### PR TITLE
add `routeDepth` into `stubRouterContext` method

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -72,16 +72,20 @@ var stubRouterContext = (Component, props, stubs) => {
     getCurrentParams () {},
     getCurrentQuery () {},
     isActive () {},
+    getRouteAtDepth() {},
+    setRouteComponentAtDepth() {}
   }, stubs)
 
   return React.createClass({
     childContextTypes: {
-      router: React.PropTypes.func
+      router: React.PropTypes.func,
+      routeDepth: React.PropTypes.number
     },
 
     getChildContext () {
       return {
-        router: RouterStub
+        router: RouterStub,
+        routeDepth: 0
       };
     },
 


### PR DESCRIPTION
Hello,

If you want to test an element with `<RouteHandler />` component in it, you need in additional the `routeDepth` into `stubRouterContext`.

I don't know the side effects but this was proposed by @taurose in the issue I have created: https://github.com/rackt/react-router/issues/1055

Best.