### PR TITLE
Fixing web pack warnings

### DIFF
--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -4,6 +4,7 @@ var { Route, RouteHandler, Link } = Router;
 
 class App extends React.Component {
   constructor () {
+    super();
     this.state = {
       loggedIn: auth.loggedIn()
     };
@@ -69,6 +70,7 @@ var Dashboard = requireAuth(class extends React.Component {
 class Login extends React.Component {
 
   constructor () {
+    super();
     this.handleSubmit = this.handleSubmit.bind(this);
     this.state = {
       error: false


### PR DESCRIPTION
First One:

ERROR in ./examples/auth-flow/app.js
Module build failed: SyntaxError:
/Users/erik/towbook/react-router/examples/auth-flow/app.js: Line 73:
'this' is not allowed before super()

Second:

ERROR in ./examples/auth-flow/app.js
Module build failed: SyntaxError:
/Users/erik/towbook/react-router/examples/auth-flow/app.js: Line 73:
'this' is not allowed before super()

Running on node v0.12.2