### PR TITLE
transition.notFound() feature

### DIFF
--- a/docs/api/Transition.md
+++ b/docs/api/Transition.md
@@ -15,6 +15,10 @@ Aborts a transition.
 
 Redirect to another route.
 
+### `notFound()`
+
+Render nearest NotFoundRoute.
+
 ### `retry()`
 
 Retries a transition. Typically you save off a transition you care to

--- a/modules/NotFoundReason.js
+++ b/modules/NotFoundReason.js
@@ -1,0 +1,7 @@
+/**
+ * Represents a not found reason
+ * that will change transition for NotFoundRoute.
+ */
+function NotFoundReason() {}
+
+module.exports = NotFoundReason;

--- a/modules/Transition.js
+++ b/modules/Transition.js
@@ -2,6 +2,7 @@
 
 var Cancellation = require('./Cancellation');
 var Redirect = require('./Redirect');
+var NotFoundReason = require('./NotFoundReason');
 
 /**
  * Encapsulates a transition to a given path.
@@ -27,6 +28,10 @@ Transition.prototype.redirect = function (to, params, query) {
 
 Transition.prototype.cancel = function () {
   this.abort(new Cancellation);
+};
+
+Transition.prototype.notFound = function () {
+  this.abort(new NotFoundReason);
 };
 
 Transition.from = function (transition, routes, components, callback) {


### PR DESCRIPTION
This PR adds feature to prevent rendering current route handler and then to render not-found route handler in transition hooks.

```javascript

class SomeComponent extends React.Component {
  static willTransitionTo(transition, params, query, callback) {
    fetchUser(params.userId).then((status, res)=> {
      if (status === 404) {
        transition.notFound();
      } else {
         // ...
      }
    });
  }
}
```