### PR TITLE
Avoid use of ES6 class getter to fix IE8

### DIFF
--- a/modules/locations/TestLocation.js
+++ b/modules/locations/TestLocation.js
@@ -11,6 +11,7 @@ class TestLocation {
     this.history = history || [];
     this.listeners = [];
     this._updateHistoryLength();
+    this.needsDOM = false;
   }
 
   _updateHistoryLength() {
@@ -69,7 +70,5 @@ class TestLocation {
   }
 
 }
-
-TestLocation.needsDOM = false;
 
 module.exports = TestLocation;

--- a/modules/locations/TestLocation.js
+++ b/modules/locations/TestLocation.js
@@ -13,10 +13,6 @@ class TestLocation {
     this._updateHistoryLength();
   }
 
-  get needsDOM() {
-    return false;
-  }
-
   _updateHistoryLength() {
     History.length = this.history.length;
   }
@@ -73,5 +69,7 @@ class TestLocation {
   }
 
 }
+
+TestLocation.needsDOM = false;
 
 module.exports = TestLocation;


### PR DESCRIPTION
This use of an ES6 getter was being transpiled into `Object.defineProperty()`, which throws an error in IE8 when creating a router.

This simply avoids the use of the getter with a minimal change. It seems that the `needsDOM` property is only used once in the codebase. Perhaps use an `instanceof` check instead?