### PR TITLE
[fixes] Case where isActive threw an error on empty routes

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -22,6 +22,15 @@ var {
 } = require('../TestUtils');
 
 describe('Router', function () {
+
+  describe('when a router is created with no routes', function() {
+    var router = Router.create({})
+
+    it ('returns false when isActive is called', function() {
+      expect(router.isActive('/bad-match')).toBe(false)
+    });
+  });
+
   describe('transitions', function () {
 
     var routes = [

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -81,7 +81,7 @@ function addRoutesToNamedRoutes(routes, namedRoutes) {
   }
 }
 
-function routeIsActive(activeRoutes, routeName) {
+function routeIsActive(activeRoutes=[], routeName) {
   return activeRoutes.some(function (route) {
     return route.name === routeName;
   });


### PR DESCRIPTION
I'm not really sure where the best place to put this test was, but when mocking out my Router during testing I ran into this:

```
TypeError: Cannot read property 'some' of undefined
	    at Array.some (native)
```

Since `state` is private to the closure of `createRouter`, it can't be mocked out. This PR sets a default for `activeRoutes` to be an empty array to account for this.