### PR TITLE
[1.0] Add ability to provide custom `render` methods on routes.

### DIFF
--- a/modules/__tests__/createRouter-test.js
+++ b/modules/__tests__/createRouter-test.js
@@ -20,13 +20,13 @@ describe('createRouter', function () {
       );
     }
   }
-  
+
   class Header extends React.Component {
     render() {
       return <div>Header</div>;
     }
   }
-  
+
   class Sidebar extends React.Component {
     render() {
       return <div>Sidebar</div>;
@@ -152,6 +152,79 @@ describe('createRouter', function () {
           throw new Error('boom!');
         });
       }).toThrow(/boom/);
+    });
+  });
+
+  describe('custom renderers', function() {
+    it('allows to provide a custom renderer', function() {
+      var wasCalled = false;
+      var render = function(component, props) {
+        expect(component).toEqual(Parent);
+        expect(Object.keys(props)).toEqual(['location', 'params', 'route']);
+        wasCalled = true;
+        return <div>Custom Render</div>;
+      };
+      var Router = createRouter(
+        <Route component={Parent} render={render} />
+      );
+
+      Router.match('/', function (error, props) {
+        var markup = renderToStaticMarkup(<Router {...props}/>);
+        expect(markup).toEqual('<div>Custom Render</div>');
+      });
+      expect(wasCalled).toBe(true);
+    });
+
+    it('walks up the route stack and calls render on every route', function() {
+      class ParentComponent extends React.Component {
+        render() {
+          return <div className="parent">{this.props.children}</div>
+        }
+      }
+      var callsA = 0;
+      var callsB = 0;
+      var callsC = 0;
+      var renderA = function(Component, props) {
+        expect(Component).toEqual(ParentComponent);
+        callsA++;
+        return <div><Component {...props} /></div>;
+      };
+      var renderB = function(Component, props) {
+        if (callsB == 0) {
+          expect(Component).toBe(Sidebar);
+        } else {
+          expect(Component).toBe(Header);
+        }
+        callsB++;
+        return (
+          <div>
+            {Component.name}
+            {props.children}
+          </div>
+        );
+      };
+      var renderC = function(Component, props) {
+        expect(Component).toEqual(Sidebar);
+        callsC++;
+        return null;
+      };
+      var Router = createRouter(
+        <Route component={ParentComponent} render={renderA}>
+          <Route component={Header} render={renderB}>
+            <Route path="app" component={Sidebar} render={renderC} />
+          </Route>
+        </Route>
+      );
+
+      Router.match('/app', function (error, props) {
+        var markup = renderToStaticMarkup(<Router {...props}/>);
+        expect(markup).toEqual(
+          '<div><div class=\"parent\"><div>Header<div>Sidebar</div></div></div></div>'
+        );
+      });
+      expect(callsA).toBe(1);
+      expect(callsB).toBe(2);
+      expect(callsC).toBe(1);
     });
   });
 

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -13,8 +13,19 @@ var findMatch = require('./findMatch');
 var Location = require('./Location');
 var AbstractHistory = require('./AbstractHistory');
 
-function createElement(component, props) {
-  return typeof component === 'function' ? React.createElement(component, props) : null;
+function createElement(branch, index, component, props) {
+  if (typeof component !== 'function') {
+    return null;
+  }
+  var element, render;
+  while (index >= 0) {
+    render = branch[index--].render;
+    element = (typeof render === 'function') ? render(component, props) : null;
+    if (element) {
+      return element;
+    }
+  }
+  return React.createElement(component, props);
 }
 
 function getComponents(route, callback) {
@@ -261,7 +272,7 @@ function createRouter(routes) {
 
           var route = branch[index];
           var props = { location, params, route };
- 
+
           if (React.isValidElement(children)) {
             props.children = children;
           } else if (children) {
@@ -275,12 +286,17 @@ function createRouter(routes) {
 
             for (var key in components)
               if (components.hasOwnProperty(key))
-                elements[key] = createElement(components[key], assign({}, props));
+                elements[key] = createElement(
+                  branch,
+                  index,
+                  components[key],
+                  assign({}, props)
+                );
 
             return elements;
           }
 
-          return createElement(components, props);
+          return createElement(branch, index, components, props);
         }, children);
       }
 


### PR DESCRIPTION
This allows to inject a custom "route handler" (hah!). This is a useful hook to render something different from react-router's default call to `React.createElement`. This method will be called for every component on every step of the route tree and it can conditionally return a `ReactElement`. This is useful when building an application with Relay.

Actual Code Example:
```js
function render(component, {params, route}) {
  var {name, queries, component} = route;
  if (name && queries && Relay.isContainer(component)) {
    return (
      <RelayRootContainer
        Component={component}
        route={{name, params, queries}}
      />
    );
  }
}

var routes = (
  <Route component={Root} render={render}>
    <Route …>
      <Route name="app" component={App} queries={{…}} />
      <Route name="profile" component={Profile} queries={{…}} />
      <Route name="events" component={Events} queries={{…}} />
    </Route>
  </Route>
);
```

The application code is not affected by this; components will just receive `this.props.children`.

It is possible that such a render function might be useful on more steps than just the top level. In this case I would consider changing my code to walk up the matched route tree and select the first render method that is defined. If we do this, we might also want to consider walking up the matched route tree and calling all render methods (closest ones first) until one of them renders to an element.