### PR TITLE
Fixes #1218 - font-family declaration misspelling

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -119,7 +119,7 @@ pre > code {
   margin: 0;
   list-style-type: none;
   padding: 0;
-  font-family: "Source Code Pro", mono-space;
+  font-family: "Source Code Pro", monospace;
 }
 
 .Version {


### PR DESCRIPTION
Fixes #1218 - Docs font-family declaration misspelling of monospace.