### PR TITLE
Add an example of animating both parent and nested routes

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -10,6 +10,7 @@
 <li><a href="dynamic-segments/index.html">Dynamic Segments</a></li>
 <li><a href="huge-apps/index.html">Huge Apps (Partial App Loading)</a></li>
 <li><a href="master-detail/index.html">Master Detail</a></li>
+<li><a href="nested-animations/index.html">Nested Animations</a></li>
 <li><a href="passing-props-to-children/index.html">Passing Props to Children</a></li>
 <li><a href="pinterest/index.html">Pinterest-style UI (location.state)</a></li>
 <li><a href="query-params/index.html">Query Params</a></li>

--- a/examples/nested-animations/app.css
+++ b/examples/nested-animations/app.css
@@ -22,7 +22,7 @@
 }
 
 .swap-leave.swap-leave-active {
-  opacity: 0.01;
+  opacity: 0;
   transform: translateX(-5em);
 }
 
@@ -41,5 +41,5 @@
 }
 
 .example-leave.example-leave-active {
-  opacity: 0.01;
+  opacity: 0;
 }

--- a/examples/nested-animations/app.css
+++ b/examples/nested-animations/app.css
@@ -1,0 +1,45 @@
+.Image {
+  position: absolute;
+  height: 400px;
+  width: 400px;
+}
+
+.swap-enter {
+  opacity: 0.01;
+  transform: translateX(5em);
+  transition: all .5s ease-in;
+}
+
+.swap-enter.swap-enter-active {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.swap-leave {
+  opacity: 1;
+  transform: translateX(0);
+  transition: all .5s ease-in;
+}
+
+.swap-leave.swap-leave-active {
+  opacity: 0.01;
+  transform: translateX(-5em);
+}
+
+.example-enter {
+  opacity: 0.01;
+  transition: opacity .5s ease-in;
+}
+
+.example-enter.example-enter-active {
+  opacity: 1;
+}
+
+.example-leave {
+  opacity: 1;
+  transition: opacity .5s ease-in;
+}
+
+.example-leave.example-leave-active {
+  opacity: 0.01;
+}

--- a/examples/nested-animations/app.js
+++ b/examples/nested-animations/app.js
@@ -1,0 +1,113 @@
+var React = require('react');
+var TransitionGroup = require('react/lib/ReactCSSTransitionGroup');
+var Router = require('react-router');
+var { Route, RouteHandler, Link } = Router;
+
+var App = React.createClass({
+
+  contextTypes: {
+    router: React.PropTypes.func
+  },
+
+  render: function () {
+    var name = this.context.router.getCurrentPath();
+    // Only take the first-level part of the path as key, instead of the whole path.
+    var key = name.split('/')[1] || 'root';
+    return (
+      <div>
+        <ul>
+          <li><Link to="page1">Page 1</Link></li>
+          <li><Link to="page2">Page 2</Link></li>
+        </ul>
+        <TransitionGroup component="div" transitionName="swap">
+          <RouteHandler key={key}/>
+        </TransitionGroup>
+      </div>
+    );
+  }
+});
+
+var Page1 = React.createClass({
+
+    contextTypes: {
+      router: React.PropTypes.func
+    },
+
+  render: function () {
+    var name = this.context.router.getCurrentPath();
+    return (
+      <div className="Image">
+        <h1>Page 1</h1>
+        <ul>
+          <li><Link to="page1-tab1">Tab 1</Link></li>
+          <li><Link to="page1-tab2">Tab 2</Link></li>
+        </ul>
+        <TransitionGroup component="div" transitionName="example">
+          <RouteHandler key={name}/>
+        </TransitionGroup>
+      </div>
+    );
+  }
+});
+
+var Page2 = React.createClass({
+
+    contextTypes: {
+      router: React.PropTypes.func
+    },
+
+  render: function () {
+    var name = this.context.router.getCurrentPath();
+    return (
+      <div className="Image">
+        <h1>Page 2</h1>
+        <ul>
+          <li><Link to="page2-tab1">Tab 1</Link></li>
+          <li><Link to="page2-tab2">Tab 2</Link></li>
+        </ul>
+        <TransitionGroup component="div" transitionName="example">
+          <RouteHandler key={name}/>
+        </TransitionGroup>
+      </div>
+    );
+  }
+});
+
+var Tab1 = React.createClass({
+  render: function () {
+    return (
+      <div className="Image">
+        <h2>Tab 1</h2>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    );
+  }
+});
+
+var Tab2 = React.createClass({
+  render: function () {
+    return (
+      <div className="Image">
+        <h2>Tab 2</h2>
+        <p>Consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      </div>
+    );
+  }
+});
+
+var routes = (
+  <Route handler={App}>
+    <Route name="page1" handler={Page1}>
+      <Route name="page1-tab1" path="tab1" handler={Tab1} />
+      <Route name="page1-tab2" path="tab2" handler={Tab2} />
+    </Route>
+    <Route name="page2" handler={Page2}>
+      <Route name="page2-tab1" path="tab1" handler={Tab1} />
+      <Route name="page2-tab2" path="tab2" handler={Tab2} />
+    </Route>
+  </Route>
+);
+
+Router.run(routes, function (Handler) {
+  React.render(<Handler/>, document.getElementById('example'));
+});

--- a/examples/nested-animations/app.js
+++ b/examples/nested-animations/app.js
@@ -1,80 +1,68 @@
-var React = require('react');
-var TransitionGroup = require('react/lib/ReactCSSTransitionGroup');
-var Router = require('react-router');
-var { Route, RouteHandler, Link } = Router;
+import React, { cloneElement } from 'react/addons';
+import HashHistory from 'react-router/lib/HashHistory';
+import { Router, Route, Link } from 'react-router';
+
+var { CSSTransitionGroup } = React.addons;
 
 var App = React.createClass({
+  render() {
 
-  contextTypes: {
-    router: React.PropTypes.func
-  },
-
-  render: function () {
-    var name = this.context.router.getCurrentPath();
     // Only take the first-level part of the path as key, instead of the whole path.
-    var key = name.split('/')[1] || 'root';
+    var pathname = this.props.location.pathname;
+    var key = pathname.split('/')[1] || 'root';
+
     return (
       <div>
         <ul>
-          <li><Link to="page1">Page 1</Link></li>
-          <li><Link to="page2">Page 2</Link></li>
+          <li><Link to="/page1">Page 1</Link></li>
+          <li><Link to="/page2">Page 2</Link></li>
         </ul>
-        <TransitionGroup component="div" transitionName="swap">
-          <RouteHandler key={key}/>
-        </TransitionGroup>
+        <CSSTransitionGroup component="div" transitionName="swap">
+          {cloneElement(this.props.children || <div/>, { key: key })}
+        </CSSTransitionGroup>
       </div>
     );
   }
 });
 
 var Page1 = React.createClass({
-
-    contextTypes: {
-      router: React.PropTypes.func
-    },
-
-  render: function () {
-    var name = this.context.router.getCurrentPath();
+  render() {
+    var key = this.props.location.pathname;
     return (
       <div className="Image">
         <h1>Page 1</h1>
         <ul>
-          <li><Link to="page1-tab1">Tab 1</Link></li>
-          <li><Link to="page1-tab2">Tab 2</Link></li>
+          <li><Link to="/page1/tab1">Tab 1</Link></li>
+          <li><Link to="/page1/tab2">Tab 2</Link></li>
         </ul>
-        <TransitionGroup component="div" transitionName="example">
-          <RouteHandler key={name}/>
-        </TransitionGroup>
+        <CSSTransitionGroup component="div" transitionName="example">
+          {cloneElement(this.props.children || <div/>, { key: key })}
+        </CSSTransitionGroup>
       </div>
     );
   }
 });
 
 var Page2 = React.createClass({
-
-    contextTypes: {
-      router: React.PropTypes.func
-    },
-
-  render: function () {
-    var name = this.context.router.getCurrentPath();
+  render() {
+    var key = this.props.location.pathname;
     return (
       <div className="Image">
         <h1>Page 2</h1>
         <ul>
-          <li><Link to="page2-tab1">Tab 1</Link></li>
-          <li><Link to="page2-tab2">Tab 2</Link></li>
+          <li><Link to="/page2/tab1">Tab 1</Link></li>
+          <li><Link to="/page2/tab2">Tab 2</Link></li>
         </ul>
-        <TransitionGroup component="div" transitionName="example">
-          <RouteHandler key={name}/>
-        </TransitionGroup>
+        <CSSTransitionGroup component="div" transitionName="example">
+          {cloneElement(this.props.children || <div/>, { key: key })}
+        </CSSTransitionGroup>
       </div>
     );
   }
 });
 
 var Tab1 = React.createClass({
-  render: function () {
+  render() {
     return (
       <div className="Image">
         <h2>Tab 1</h2>
@@ -85,7 +73,7 @@ var Tab1 = React.createClass({
 });
 
 var Tab2 = React.createClass({
-  render: function () {
+  render() {
     return (
       <div className="Image">
         <h2>Tab 2</h2>
@@ -95,19 +83,17 @@ var Tab2 = React.createClass({
   }
 });
 
-var routes = (
-  <Route handler={App}>
-    <Route name="page1" handler={Page1}>
-      <Route name="page1-tab1" path="tab1" handler={Tab1} />
-      <Route name="page1-tab2" path="tab2" handler={Tab2} />
+React.render((
+  <Router history={HashHistory}>
+    <Route path="/" component={App}>
+      <Route path="page1" component={Page1}>
+        <Route path="tab1" component={Tab1} />
+        <Route path="tab2" component={Tab2} />
+      </Route>
+      <Route path="page2" component={Page2}>
+        <Route path="tab1" component={Tab1} />
+        <Route path="tab2" component={Tab2} />
+      </Route>
     </Route>
-    <Route name="page2" handler={Page2}>
-      <Route name="page2-tab1" path="tab1" handler={Tab1} />
-      <Route name="page2-tab2" path="tab2" handler={Tab2} />
-    </Route>
-  </Route>
-);
-
-Router.run(routes, function (Handler) {
-  React.render(<Handler/>, document.getElementById('example'));
-});
+  </Router>
+), document.getElementById('example'));

--- a/examples/nested-animations/index.html
+++ b/examples/nested-animations/index.html
@@ -1,0 +1,9 @@
+<!doctype html public "restroom">
+<title>Nested Animations Example</title>
+<link href="../global.css" rel="stylesheet"/>
+<link href="app.css" rel="stylesheet"/>
+<body>
+<h1 class="breadcrumbs"><a href="../index.html">React Router Examples</a> / Nested Animations</h1>
+<div id="example"/>
+<script src="/__build__/shared.js"></script>
+<script src="/__build__/nested-animations.js"></script>


### PR DESCRIPTION
Hey,

this is based on the "animations" example. It goes further by adding nested routes that are animated as well. I think it is worth a separate example as making this work is not as simple as combining examples for animation and examples for nesting. I had a hard time figuring it out, and this issue is not uncommon (https://github.com/rackt/react-router/issues/1129, https://github.com/rackt/react-router/issues/874).


The interesting bit:

```javascript
var App = React.createClass({
  render() {
    // Only take the first-level part of the path as key, instead of the whole path.
    var pathname = this.props.location.pathname;
    var key = pathname.split('/')[1] || 'root';

    return (
      <CSSTransitionGroup component="div" transitionName="swap">
        {cloneElement(this.props.children || <div/>, { key: key })}
      </CSSTransitionGroup>
    );
  }
});
```

This approach is similar to the one described in [this blog post](http://unitstep.net/blog/2015/03/03/using-react-animations-to-transition-between-ui-states/). I'm not sure how much of a hack that is, but it works! 