### PR TITLE
Allow "null" and "undefined" in routes

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -863,6 +863,19 @@ describe('Router.run', function () {
     });
   });
 
+  it('matches an array of routes including null', function (done) {
+    var routes = [
+      <Route handler={Foo} path="/foo"/>,
+      null,
+      <Route handler={Bar} path="/bar"/>
+    ];
+    Router.run(routes, '/bar', function (Handler, state) {
+      var html = React.renderToString(<Handler/>);
+      expect(html).toMatch(/Bar/);
+      done();
+    });
+  });
+
   it('matches nested routes', function (done) {
     var routes = (
       <Route handler={Nested} path='/'>

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -66,6 +66,9 @@ function addRoutesToNamedRoutes(routes, namedRoutes) {
   for (var i = 0, len = routes.length; i < len; ++i) {
     route = routes[i];
 
+    if (!route)
+      continue;
+
     if (route.name) {
       invariant(
         namedRoutes[route.name] == null,


### PR DESCRIPTION
This matches [React convention since 0.11](https://facebook.github.io/react/blog/2014/07/17/react-v0.11.html#rendering-to-null) so routes may be specified like this:

```
    <Route name="landing" path="/" handler={ LandingRoute }>,
    (
      config.env === 'development'
      && <Route name="styleguide" handler={ StyleGuideRoute } />
    ),
    <NotFoundRoute handler={ NotFound } />
```

In regular React, they'll be rendered as `<noscript>` but will eventually be skipped altogether. In react-router, they'll simply be ignored during iteration.