### PR TITLE
Run path components through encode/decodeURIComponent

### DIFF
--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -18,9 +18,7 @@ export function replaceHashPath(path) {
 }
 
 export function getWindowPath() {
-  return decodeURI(
-    window.location.pathname + window.location.search
-  );
+  return window.location.pathname + window.location.search;
 }
 
 export function getWindowScrollPosition() {

--- a/modules/URLUtils.js
+++ b/modules/URLUtils.js
@@ -116,7 +116,9 @@ export function matchPattern(pattern, pathname) {
 
   var remainingPathname, paramValues;
   if (match != null) {
-    paramValues = Array.prototype.slice.call(match, 1);
+    paramValues = Array.prototype.slice.call(match, 1).map(
+      (v) => v != null ? decodeURIComponent(v) : v
+    );
 
     if (captureRemaining) {
       remainingPathname = paramValues.pop();
@@ -176,7 +178,7 @@ export function formatPattern(pattern, params) {
       );
 
       if (paramValue != null)
-        pathname += paramValue;
+        pathname += encodeURIComponent(paramValue);
     } else {
       pathname += token;
     }

--- a/modules/__tests__/URLUtils-test.js
+++ b/modules/__tests__/URLUtils-test.js
@@ -73,13 +73,13 @@ describe('formatPattern', function () {
 
     describe('and some params have special URL encoding', function () {
       it('returns the correct path', function () {
-        expect(formatPattern(pattern, { id: 'one, two' })).toEqual('comments/one, two/edit');
+        expect(formatPattern(pattern, { id: 'one, two' })).toEqual('comments/one%2C%20two/edit');
       });
     });
 
     describe('and a param has a forward slash', function () {
       it('preserves the forward slash', function () {
-        expect(formatPattern(pattern, { id: 'the/id' })).toEqual('comments/the/id/edit');
+        expect(formatPattern(pattern, { id: 'the/id' })).toEqual('comments/the%2Fid/edit');
       });
     });
 


### PR DESCRIPTION
This changes the behavior of `PathUtils.injectParams`. I'm not sure if there was some important reasoning behind preserving a `/` in a path component, but it seems to me that it would break reloading unless the pattern in question was a splat.

That is, given a pattern like `/foo/:id/bar`, if `id` is set to `baz/qux`, then before this patch the final URL would be `/foo/baz/qux/bar`. Upon reload, the pattern would fail to match and the router would 404. With this patch, the URL ends up being `/foo/baz%2Fqux/bar`, which correctly matches the pattern.

The API-facing behavior remains unchanged.

This fixes #1264 and #1128.