### PR TITLE
[added] Router#transitionToMixin and Router#replaceWithMixin

### DIFF
--- a/modules/Navigation.js
+++ b/modules/Navigation.js
@@ -57,6 +57,22 @@ var Navigation = {
   },
 
   /**
+   * Transitions to the current URL with updated params and query by
+   * pushing a new URL onto the history stack.
+   */
+  transitionToMixin(to, params, query) {
+    this.context.router.transitionToMixin(to, params, query);
+  },
+
+  /**
+   * Tranition to the current URL with updated params and query by
+   * replacing the current URL in the history stack.
+   */
+  replaceWithMixin(to, params, query) {
+    this.context.router.replaceWithMixin(to, params, query);
+  },
+
+  /**
    * Transitions to the previous URL.
    */
   goBack() {

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -849,6 +849,224 @@ describe('Router.makePath', function () {
   });
 });
 
+describe('Router.transitionToMixin', function () {
+
+  var routes = (
+    <Route name="home" path="/" handler={Foo}>
+      <Route name="users" handler={Foo}>
+        <Route name="user" path=":userId" handler={Foo}>
+          <Route name="orders" handler={Foo}>
+            <Route name="order" path=":orderId" handler={Foo} />
+          </Route>
+        </Route>
+      </Route>
+    </Route>
+  );
+
+  describe('when updating only the to', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users/1/orders/100' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.transitionToMixin('user', null, null);
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users/1');
+        expect(location.history.length).toEqual(2);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+  describe('when updating a single param', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users/1/orders/100' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.transitionToMixin(null, { orderId: 101 }, null);
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users/1/orders/101');
+        expect(location.history.length).toEqual(2);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+  describe('when updating a query param', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users?sortBy=name&sortDir=desc' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.transitionToMixin(null, null, { sortDir: 'asc' });
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users?sortBy=name&sortDir=asc');
+        expect(location.history.length).toEqual(2);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+});
+
+describe('Router.replaceWithMixin', function () {
+
+  var routes = (
+    <Route name="home" path="/" handler={Foo}>
+      <Route name="users" handler={Foo}>
+        <Route name="user" path=":userId" handler={Foo}>
+          <Route name="orders" handler={Foo}>
+            <Route name="order" path=":orderId" handler={Foo} />
+          </Route>
+        </Route>
+      </Route>
+    </Route>
+  );
+
+  describe('when updating only the to', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users/1/orders/100' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.replaceWithMixin('user', null, null);
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users/1');
+        expect(location.history.length).toEqual(1);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+  describe('when updating a single param', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users/1/orders/100' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.replaceWithMixin(null, { orderId: 101 }, null);
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users/1/orders/101');
+        expect(location.history.length).toEqual(1);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+  describe('when updating a query param', function () {
+    it('transition to the correct path', function (done) {
+      var location = new TestLocation([ '/users?sortBy=name&sortDir=desc' ]);
+
+      var div = document.createElement('div');
+      var steps = [];
+      var router;
+
+      steps.push(function () {
+        router.replaceWithMixin(null, null, { sortDir: 'asc' });
+      });
+
+      steps.push(function () {
+        expect(router.getCurrentPath()).toEqual('/users?sortBy=name&sortDir=asc');
+        expect(location.history.length).toEqual(1);
+        done();
+      });
+
+      router = Router.create({
+        routes: routes,
+        location: location
+      });
+
+      router.run(function (Handler) {
+        React.render(<Handler/>, div, function () {
+          steps.shift()();
+        });
+      });
+    });
+  });
+
+});
+
 describe('Router.run', function () {
 
   it('matches a root route', function (done) {

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -2,6 +2,7 @@
 var React = require('react');
 var warning = require('react/lib/warning');
 var invariant = require('react/lib/invariant');
+var assign = require('react/lib/Object.assign');
 var canUseDOM = require('react/lib/ExecutionEnvironment').canUseDOM;
 var LocationActions = require('./actions/LocationActions');
 var ImitateBrowserBehavior = require('./behaviors/ImitateBrowserBehavior');
@@ -261,6 +262,34 @@ function createRouter(options) {
        */
       replaceWith: function (to, params, query) {
         location.replace(Router.makePath(to, params, query));
+      },
+
+      /**
+       * Transitions to the current URL with updated params and query by
+       * pushing a new URL onto the history stack.
+       */
+      transitionToMixin: function (to, params, query) {
+        var routes = this.getCurrentRoutes();
+
+        to = to || routes[routes.length - 1].path;
+        params = assign({}, this.getCurrentParams(), params);
+        query = assign({}, this.getCurrentQuery(), query);
+
+        this.transitionTo(to, params, query);
+      },
+
+      /**
+       * Tranition to the current URL with updated params and query by
+       * replacing the current URL in the history stack.
+       */
+      replaceWithMixin: function (to, params, query) {
+        var routes = this.getCurrentRoutes();
+
+        to = to || routes[routes.length - 1].path;
+        params = assign({}, this.getCurrentParams(), params);
+        query = assign({}, this.getCurrentQuery(), query);
+
+        this.replaceWith(to, params, query);
       },
 
       /**


### PR DESCRIPTION
It's often desirable to transition to a new state changing only a single
part of the URL. This is currently cumbersome as Router.transitionTo and
Router.replaceWith both require the full state of the new URL.

Router#transitionToMixin and Router#replaceWithMixin are identical to
their non-Mixin siblings, however, they use the current router state,
augmenting it with the provided values.

These new methods are also exposed on the Navigation mixin.

For example using the current Navigation and State mixins:

    // before
    var query = this.getQuery();
    query.sortDir = 'desc';
    this.replaceWith(
      this.getPathname(),
      this.getParams(),
      query
    );

    // after
    this.replaceWithMixin(null, null, { sortDir: 'desc' });

Issue: #378