### PR TITLE
Fixed incomplete edits

### DIFF
--- a/doc/02 Components/Link.md
+++ b/doc/02 Components/Link.md
@@ -7,7 +7,7 @@ applies its `activeClassName` and/or `activeStyle` when it is.
 Props
 -----
 
-### `href`
+### `to`
 
 The path to link to, ie `/users/123`.
 

--- a/doc/02 Components/Link.md
+++ b/doc/02 Components/Link.md
@@ -9,11 +9,11 @@ Props
 
 ### `to`
 
-The path to link to, ie `/users/123`.
+The path to link to, e.g., `/users/123`.
 
 ### `query`
 
-An object of key:value pairs to be stingified.
+An object of key:value pairs to be stringified.
 
 ### `activeClassName`
 

--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -76,7 +76,7 @@ var Login = React.createClass({
 
       var { location } = this.props;
 
-      if (location.query && location.state.nextPathname) {
+      if (location.state && location.state.nextPathname) {
         this.replaceWith(location.state.nextPathname);
       } else {
         this.replaceWith('/about');

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -21,12 +21,12 @@ function isModifiedEvent(event) {
  *
  * You could use the following component to link to that route:
  *
- *   <Link to="showPost" params={{ postID: "123" }} />
+ *   <Link to={`/posts/${post.id}`} />
  *
- * In addition to params, links may pass along query string parameters
+ * Links may pass along query string parameters
  * using the `query` prop.
  *
- *   <Link to="showPost" params={{ postID: "123" }} query={{ show:true }}/>
+ *   <Link to="/posts/123" query={{ show:true }}/>
  */
 export var Link = React.createClass({
 


### PR DESCRIPTION
Looks like replacing `location.query` with `location.state` was incomplete.

Also fixed `Link`'s property name in docs (`s/href/to`) and examples in its doc comments.