### PR TITLE
[changed] Export history classes

### DIFF
--- a/doc/03 History/BrowserHistory.md
+++ b/doc/03 History/BrowserHistory.md
@@ -43,10 +43,10 @@ Example
 
 ```js
 import { Router } from 'react-router';
-import History from 'react-router/lib/BrowserHistory';
+import BrowserHistory from 'react-router/lib/BrowserHistory';
 
 React.render((
-  <Router history={History}>
+  <Router history={new BrowserHistory}>
     {/* ... */}
   </Router>
 ), document.body);

--- a/doc/03 History/HashHistory.md
+++ b/doc/03 History/HashHistory.md
@@ -33,10 +33,10 @@ Normal usage
 
 ```js
 import { Router } from 'react-router';
-import History from 'react-router/lib/HashHistory';
+import HashHistory from 'react-router/lib/HashHistory';
 
 React.render((
-  <Router history={History}>
+  <Router history={new HashHistory}>
     {/* ... */}
   </Router>
 ), document.body);
@@ -45,7 +45,7 @@ React.render((
 Opting in to the `state` features:
 
 ```js
-import { HashHistory } from 'react-router/lib/HashHistory';
+import HashHistory from 'react-router/lib/HashHistory';
 
 // use the default key which is `_key`
 var history = new HashHistory({ queryKey: true });

--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -19,7 +19,7 @@ function updateCurrentState(extraState) {
  * refreshes if HTML5 history is not available, so URLs are always
  * the same across browsers.
  */
-export class BrowserHistory extends DOMHistory {
+class BrowserHistory extends DOMHistory {
 
   constructor(options) {
     super(options);
@@ -108,4 +108,4 @@ export class BrowserHistory extends DOMHistory {
 
 }
 
-export default new BrowserHistory;
+export default BrowserHistory;

--- a/modules/HashHistory.js
+++ b/modules/HashHistory.js
@@ -62,13 +62,13 @@ function updateCurrentState(queryKey, extraState) {
  * Support for persistence of state across page refreshes is provided using a
  * combination of a URL query string parameter and DOM storage. However, this
  * support is not enabled by default. In order to use it, create your own
- * HashHistory, like this:
+ * HashHistory.
  *
- *   import { HashHistory } from 'react-router/lib/HashHistory';
+ *   import HashHistory from 'react-router/lib/HashHistory';
  *   var StatefulHashHistory = new HashHistory({ queryKey: '_key' });
  *   React.render(<Router history={StatefulHashHistory} .../>, ...);
  */
-export class HashHistory extends DOMHistory {
+class HashHistory extends DOMHistory {
 
   constructor(options={}) {
     super(options);
@@ -170,4 +170,4 @@ export class HashHistory extends DOMHistory {
 
 }
 
-export default new HashHistory;
+export default HashHistory;

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -2,5 +2,5 @@ import describeHistory from './describeHistory';
 import BrowserHistory from '../BrowserHistory';
 
 describe('BrowserHistory', function () {
-  describeHistory(BrowserHistory);
+  describeHistory(new BrowserHistory);
 });

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -2,5 +2,5 @@ import describeHistory from './describeHistory';
 import HashHistory from '../HashHistory';
 
 describe('HashHistory', function () {
-  describeHistory(HashHistory);
+  describeHistory(new HashHistory);
 });

--- a/modules/__tests__/scrollManagement-test.js
+++ b/modules/__tests__/scrollManagement-test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import React, { render } from 'react';
-import { HashHistory } from '../HashHistory';
+import HashHistory from '../HashHistory';
 import { getWindowScrollPosition } from '../DOMUtils';
 import Router from '../Router';
 import Route from '../Route';


### PR DESCRIPTION
This commit normalizes the way we export history classes. Instead of automatically creating a new Browser/HashHistory for people when they require the module, we just export the class like we do with History and MemoryHistory.

This gives us a few things:

- We don't have to explain to people that they need to `import { HashHistory }` in order to create their own HashHistory.
- We don't require people using CommonJS to `var HashHistory = require('react-router/lib/HashHistory').default`, which sucks