### PR TITLE
added failing test for TransitionHook on not selectively calling routerWillLeave

### DIFF
--- a/modules/__tests__/TransitionHook-test.js
+++ b/modules/__tests__/TransitionHook-test.js
@@ -50,4 +50,87 @@ describe('TransitionHook', function () {
       </Router>
     ), div, execNextStep);
   });
+  it('selectively calls routerWillLeave by route, in the correct order', function (done) {
+    var div = document.createElement('div');
+    var calls = [];
+    var timeout = 0;
+
+    var Grandparent = React.createClass({
+      mixins: [ TransitionHook ],
+      routerWillLeave(nextState, router, callback) {
+        setTimeout(function() {
+          calls.push("grandparent-leave")
+          callback();
+        }, timeout)
+      },
+      render() {
+        return <div>grandparent<div>{this.props.children}</div></div>;
+      }
+    });
+
+    var ParentA = React.createClass({
+      componentDidMount() {
+        calls.push("parentA-enter");
+      },
+      render() {
+        return <div>parentA</div>;
+      }
+    });
+
+    var ParentB = React.createClass({
+      mixins: [ TransitionHook ],
+      routerWillLeave(nextState, router, callback) {
+        setTimeout(function() {
+          calls.push("parentB-leave");
+          callback();
+        }, timeout)
+      },
+      render() {
+        return <div>parentB<div>{this.props.children}</div></div>;
+      }
+    });
+
+    var Child = React.createClass({
+      mixins: [ TransitionHook ],
+      routerWillLeave(nextState, router, callback) {
+        setTimeout(function() {
+          calls.push("child-leave");
+          callback();
+        }, timeout)
+      },
+      render() {
+        return <div>child</div>;
+      }
+    });
+
+
+    var steps = [
+      function () {
+        expect(this.state.location.pathname).toEqual('/grandparent/parentB/child');
+        expect(div.textContent.trim()).toEqual('grandparentparentBchild');
+        this.transitionTo('/grandparent/parentA')
+      },
+      function () {
+        expect(this.state.location.pathname).toEqual('/grandparent/parentA');
+        expect(div.textContent.trim()).toEqual('grandparentparentA');
+        expect(calls).toEqual(["child-leave", "parentB-leave", "parentA-enter"]);
+        done();
+      }
+    ];
+
+    function execNextStep() {
+      steps.shift().apply(this, arguments);
+    }
+
+    render((
+      <Router history={new MemoryHistory('/grandparent/parentB/child')} onUpdate={execNextStep}>
+        <Route path="grandparent" component={Grandparent}>
+            <Route path="parentA" component={ParentA}/>
+            <Route path="parentB" component={ParentB}>
+                <Route path="child" component={Child}/>
+            </Route>
+        </Route>
+      </Router>
+    ), div, execNextStep);
+  });
 });


### PR DESCRIPTION
In reference to issue #1317 

Fails as of 285a61f

When transitioning from `/grandparent/parentB/child` to `/grandparent/parentA`, it calls `Grandparent.routerWillLeave`, which it should not.