### PR TITLE
Quick fix to Passing Props to Children example

### DIFF
--- a/examples/passing-props-to-children/app.js
+++ b/examples/passing-props-to-children/app.js
@@ -72,7 +72,7 @@ var Taco = React.createClass({
 });
 
 React.render((
-  <Router history={HashHistory}>
+  <Router history={new HashHistory}>
     <Route path="/" component={App}>
       <Route path="taco/:name" component={Taco}/>
     </Route>


### PR DESCRIPTION
Added the missing new keyword to HashHistory