### PR TITLE
Add 'new' to HashHistory instantiation

### DIFF
--- a/doc/00 Guides/0 Overview.md
+++ b/doc/00 Guides/0 Overview.md
@@ -141,7 +141,7 @@ var App = React.createClass({
 // Finally we render a `Router` component with some `Route`s, it'll do all
 // the fancy routing stuff for us.
 React.render((
-  <Router history={HashHistory}>
+  <Router history={new HashHistory}>
     <Route path="/" component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}/>
@@ -191,7 +191,7 @@ var Inbox = React.createClass({
 });
 
 React.render((
-  <Router history={HashHistory}>
+  <Router history={new HashHistory}>
     <Route component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}>
@@ -230,4 +230,3 @@ var Message = React.createClass({
 That's the gist of React Router. Application UIs are boxes inside of
 boxes inside of boxes; now you can keep those boxes in sync with the
 URL.
-


### PR DESCRIPTION
http://rackt.github.io/react-router/tags/v1.0.0-beta2.html#Overview
The 'new' keyword for instantiating HashHistory is missing in the examples.