### PR TITLE
Use detachEvent in old IE

### DIFF
--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -73,7 +73,7 @@ class BrowserHistory extends DOMHistory {
       if (window.removeEventListener) {
         window.removeEventListener('popstate', this.handlePopState, false);
       } else {
-        window.removeEvent('onpopstate', this.handlePopState);
+        window.detachEvent('onpopstate', this.handlePopState);
       }
     }
   }

--- a/modules/HashHistory.js
+++ b/modules/HashHistory.js
@@ -123,7 +123,7 @@ class HashHistory extends DOMHistory {
       if (window.removeEventListener) {
         window.removeEventListener('hashchange', this.handleHashChange, false);
       } else {
-        window.removeEvent('onhashchange', this.handleHashChange);
+        window.detachEvent('onhashchange', this.handleHashChange);
       }
     }
   }


### PR DESCRIPTION
IE8 gives an error:
> Object doesn't support this property or method

It is fixed by the use of `detachEvent`.