### PR TITLE
Add tests for incorrect onEnter/onLeave Redirect behavior

### DIFF
--- a/modules/__tests__/Redirect-test.js
+++ b/modules/__tests__/Redirect-test.js
@@ -26,4 +26,47 @@ describe('A <Redirect>', function () {
       done();
     });
   });
+
+  it('calls onEnter but not onLeave', function (done) {
+    var enterCalled = 0;
+    var leaveCalled = 0;
+    var onEnter = function () { enterCalled++ };
+    var onLeave = function() { leaveCalled++ };
+    render((
+      <Router history={new MemoryHistory('/notes/5')}>
+        <Route onEnter={onEnter} onLeave={onLeave}>
+          <Route path="messages/:id"/>
+          <Redirect from="notes/:id" to="/messages/:id"/>
+        </Route>
+      </Router>
+    ), node, function() {
+      expect(enterCalled).toEqual(1);
+      expect(leaveCalled).toEqual(0);
+      done();
+    });
+  });
+
+  it('doesn\'t call onEnter or onLeave when redirecting inside the same parent', function (done) {
+    var enterCalled = 0;
+    var leaveCalled = 0;
+    var onEnter = function () { enterCalled++ };
+    var onLeave = function() { leaveCalled++ };
+    render((
+      <Router history={new MemoryHistory('/messages/5/details')}>
+        <Route onEnter={onEnter} onLeave={onLeave}>
+          <Redirect from="messages/:id" to="/messages/:id/details"/>
+          <Route path="messages/:id/details"/>
+        </Route>
+      </Router>
+    ), node, function() {
+      expect(this.state.location.pathname).toEqual('/messages/5/details');
+      expect(enterCalled).toEqual(1);
+      expect(leaveCalled).toEqual(0);
+      this.transitionTo("/messages/6");
+      expect(this.state.location.pathname).toEqual('/messages/6/details');
+      expect(enterCalled).toEqual(1);
+      expect(leaveCalled).toEqual(0);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
As per a conversation in Slack with @mjackson.

I'm not positive if the expected behavior of the second test is correct. Note that the test, as written, passes if the `<Redirect />` is moved up one line (to be directly under `<Router />`).