### PR TITLE
Update Histories

### DIFF
--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -43,7 +43,7 @@ class BrowserHistory extends DOMHistory {
     if (this.isSupported && window.history.state)
       key = window.history.state.key;
 
-    super.setup(path, {key});
+    super.setup(path, { key });
   }
 
   handlePopState(event) {
@@ -52,7 +52,7 @@ class BrowserHistory extends DOMHistory {
 
     var path = getWindowPath();
     var key = event.state && event.state.key;
-    this.handlePop(path, {key});
+    this.handlePop(path, { key });
   }
 
   addChangeListener(listener) {

--- a/modules/BrowserHistory.js
+++ b/modules/BrowserHistory.js
@@ -2,13 +2,6 @@ import DOMHistory from './DOMHistory';
 import { getWindowPath, supportsHistory } from './DOMUtils';
 import NavigationTypes from './NavigationTypes';
 
-function updateCurrentState(extraState) {
-  var state = window.history.state;
-
-  if (state)
-    window.history.replaceState(Object.assign(state, extraState), '');
-}
-
 /**
  * A history implementation for DOM environments that support the
  * HTML5 history API (pushState, replaceState, and the popstate event).
@@ -42,16 +35,24 @@ class BrowserHistory extends DOMHistory {
   }
 
   setup() {
-    if (this.location == null)
-      this._updateLocation();
+    if (this.location != null)
+      return;
+
+    var path = getWindowPath();
+    var key = null;
+    if (this.isSupported && window.history.state)
+      key = window.history.state.key;
+
+    super.setup(path, {key});
   }
 
   handlePopState(event) {
     if (event.state === undefined)
       return; // Ignore extraneous popstate events in WebKit.
 
-    this._updateLocation(NavigationTypes.POP);
-    this._notifyChange();
+    var path = getWindowPath();
+    var key = event.state && event.state.key;
+    this.handlePop(path, {key});
   }
 
   addChangeListener(listener) {
@@ -79,31 +80,24 @@ class BrowserHistory extends DOMHistory {
   }
 
   // http://www.w3.org/TR/2011/WD-html5-20110113/history.html#dom-history-pushstate
-  pushState(state, path) {
+  push(path, key) {
     if (this.isSupported) {
-      updateCurrentState(this.getScrollPosition());
-
-      state = this._createState(state);
-
+      var state = { key };
       window.history.pushState(state, '', path);
-      this.location = this.createLocation(path, state, NavigationTypes.PUSH);
-      this._notifyChange();
-    } else {
-      window.location = path;
+      return state;
     }
+
+    window.location = path;
   }
 
   // http://www.w3.org/TR/2011/WD-html5-20110113/history.html#dom-history-replacestate
-  replaceState(state, path) {
+  replace(path, key) {
     if (this.isSupported) {
-      state = this._createState(state);
-
+      var state = { key };
       window.history.replaceState(state, '', path);
-      this.location = this.createLocation(path, state, NavigationTypes.REPLACE);
-      this._notifyChange();
-    } else {
-      window.location.replace(path);
+      return state;
     }
+    window.location.replace(path);
   }
 
 }

--- a/modules/DOMHistory.js
+++ b/modules/DOMHistory.js
@@ -18,6 +18,36 @@ class DOMHistory extends History {
     window.history.go(n);
   }
 
+  saveState(key, state) {
+    window.sessionStorage.setItem(key, JSON.stringify(state));
+  }
+
+  readState(key) {
+    var json = window.sessionStorage.getItem(key);
+
+    if (json) {
+      try {
+        return JSON.parse(json);
+      } catch (error) {
+        // Ignore invalid JSON in session storage.
+      }
+    }
+
+    return null;
+  }
+
+  pushState(state, path) {
+    var location = this.location;
+    if (location && location.state && location.state.key) {
+      var key = location.state.key;
+      var curState = this.readState(key);
+      var scroll = this.getScrollPosition();
+      this.saveState(key, {...curState, ...scroll});
+    }
+
+    super.pushState(state, path);
+  }
+
 }
 
 export default DOMHistory;

--- a/modules/HashHistory.js
+++ b/modules/HashHistory.js
@@ -1,6 +1,5 @@
 import warning from 'warning';
 import DOMHistory from './DOMHistory';
-import NavigationTypes from './NavigationTypes';
 import { getHashPath, replaceHashPath } from './DOMUtils';
 import { isAbsolutePath } from './URLUtils';
 
@@ -24,34 +23,6 @@ function addQueryStringValueToPath(path, key, value) {
 function getQueryStringValueFromPath(path, key) {
   var match = path.match(new RegExp(`\\?.*?\\b${key}=(.+?)\\b`));
   return match && match[1];
-}
-
-function saveState(path, queryKey, state) {
-  window.sessionStorage.setItem(state.key, JSON.stringify(state));
-  return addQueryStringValueToPath(path, queryKey, state.key);
-}
-
-function readState(path, queryKey) {
-  var sessionKey = getQueryStringValueFromPath(path, queryKey);
-  var json = sessionKey && window.sessionStorage.getItem(sessionKey);
-  
-  if (json) {
-    try {
-      return JSON.parse(json);
-    } catch (error) {
-      // Ignore invalid JSON in session storage.
-    }
-  }
-
-  return null;
-}
-
-function updateCurrentState(queryKey, extraState) {
-  var path = getHashPath();
-  var state = readState(path, queryKey);
-
-  if (state)
-    saveState(path, queryKey, Object.assign(state, extraState));
 }
 
 /**
@@ -79,17 +50,15 @@ class HashHistory extends DOMHistory {
       this.queryKey = this.queryKey ? DefaultQueryKey : null;
   }
 
-  _updateLocation(navigationType) {
-    var path = getHashPath();
-    var state = this.queryKey ? readState(path, this.queryKey) : null;
-    this.location = this.createLocation(path, state, navigationType);
-  }
-
   setup() {
-    if (this.location == null) {
-      ensureSlash();
-      this._updateLocation();
-    }
+    if (this.location != null)
+      return;
+
+    ensureSlash();
+
+    var path = getHashPath();
+    var key = getQueryStringValueFromPath(path, this.queryKey);
+    super.setup(path, { key });
   }
 
   handleHashChange() {
@@ -99,8 +68,9 @@ class HashHistory extends DOMHistory {
     if (this._ignoreNextHashChange) {
       this._ignoreNextHashChange = false;
     } else {
-      this._updateLocation(NavigationTypes.POP);
-      this._notifyChange();
+      var path = getHashPath();
+      var key = getQueryStringValueFromPath(path, this.queryKey);
+      this.handlePop(path, { key });
     }
   }
 
@@ -128,40 +98,38 @@ class HashHistory extends DOMHistory {
     }
   }
 
-  pushState(state, path) {
-    warning(
-      this.queryKey || state == null,
-      'HashHistory needs a queryKey in order to persist state'
-    );
-
+  push(path, key) {
+    var actualPath = path;
     if (this.queryKey)
-      updateCurrentState(this.queryKey, this.getScrollPosition());
+      actualPath = addQueryStringValueToPath(path, this.queryKey, key);
 
-    state = this._createState(state);
 
-    if (this.queryKey)
-      path = saveState(path, this.queryKey, state);
+    if (actualPath === getHashPath()) {
+      warning(
+        false,
+        'HashHistory can not push the current path'
+      );
+    } else {
+      this._ignoreNextHashChange = true;
+      window.location.hash = actualPath;
+    }
 
-    this._ignoreNextHashChange = true;
-    window.location.hash = path;
-
-    this.location = this.createLocation(path, state, NavigationTypes.PUSH);
-
-    this._notifyChange();
+    return { key: this.queryKey && key };
   }
 
-  replaceState(state, path) {
-    state = this._createState(state);
 
+  replace(path, key) {
+    var actualPath = path;
     if (this.queryKey)
-      path = saveState(path, this.queryKey, state);
+      actualPath = addQueryStringValueToPath(path, this.queryKey, key);
 
-    this._ignoreNextHashChange = true;
-    replaceHashPath(path);
 
-    this.location = this.createLocation(path, state, NavigationTypes.REPLACE);
+    if (actualPath !== getHashPath())
+      this._ignoreNextHashChange = true;
 
-    this._notifyChange();
+    replaceHashPath(actualPath);
+
+    return { key: this.queryKey && key };
   }
 
   makeHref(path) {

--- a/modules/History.js
+++ b/modules/History.js
@@ -56,7 +56,7 @@ class History {
     if (typeof this.readState === 'function')
       state = this.readState(entry.key);
 
-    this._handleChange(path, state, entry, NavigationTypes.POP, false);
+    this._update(path, state, entry, NavigationTypes.POP, false);
   }
 
   handlePop(path, entry = {}) {
@@ -64,7 +64,7 @@ class History {
     if (entry.key && typeof this.readState === 'function')
       state = this.readState(entry.key);
 
-    this._handleChange(path, state, entry, NavigationTypes.POP);
+    this._update(path, state, entry, NavigationTypes.POP);
   }
 
   createRandomKey() {
@@ -103,7 +103,7 @@ class History {
       this.constructor.name
     );
 
-    this._handleChange(path, state, entry, NavigationTypes.PUSH);
+    this._update(path, state, entry, NavigationTypes.PUSH);
   }
 
   replaceState(state, path) {
@@ -117,7 +117,7 @@ class History {
       this.constructor.name
     );
 
-    this._handleChange(path, state, entry, NavigationTypes.REPLACE);
+    this._update(path, state, entry, NavigationTypes.REPLACE);
   }
 
   back() {
@@ -128,7 +128,7 @@ class History {
     this.go(1);
   }
 
-  _handleChange(path, state, entry, navigationType, notify=true) {
+  _update(path, state, entry, navigationType, notify=true) {
     this.path = path;
     this.location = this._createLocation(path, state, entry, navigationType);
 

--- a/modules/History.js
+++ b/modules/History.js
@@ -56,7 +56,7 @@ class History {
     if (typeof this.readState === 'function')
       state = this.readState(entry.key);
 
-    this.location = this._createLocation(path, state, entry);
+    this._handleChange(path, state, entry, NavigationTypes.POP, false);
   }
 
   handlePop(path, entry = {}) {
@@ -64,8 +64,7 @@ class History {
     if (entry.key && typeof this.readState === 'function')
       state = this.readState(entry.key);
 
-    this.location = this._createLocation(path, state, entry, NavigationTypes.POP);
-    this._notifyChange();
+    this._handleChange(path, state, entry, NavigationTypes.POP);
   }
 
   createRandomKey() {
@@ -92,7 +91,7 @@ class History {
     var key = this._saveNewState(state);
 
     var entry = null;
-    if (this.location && this.location.path === path) {
+    if (this.path === path) {
       entry = this.replace(path, key) || {};
     } else {
       entry = this.push(path, key) || {};
@@ -104,8 +103,7 @@ class History {
       this.constructor.name
     );
 
-    this.location = this._createLocation(path, state, entry, NavigationTypes.PUSH);
-    this._notifyChange();
+    this._handleChange(path, state, entry, NavigationTypes.PUSH);
   }
 
   replaceState(state, path) {
@@ -119,8 +117,7 @@ class History {
       this.constructor.name
     );
 
-    this.location = this._createLocation(path, state, entry, NavigationTypes.REPLACE);
-    this._notifyChange();
+    this._handleChange(path, state, entry, NavigationTypes.REPLACE);
   }
 
   back() {
@@ -131,11 +128,19 @@ class History {
     this.go(1);
   }
 
+  _handleChange(path, state, entry, navigationType, notify=true) {
+    this.path = path;
+    this.location = this._createLocation(path, state, entry, navigationType);
+
+    if (notify)
+      this._notifyChange();
+  }
+
   _createLocation(path, state, entry, navigationType) {
     var pathname = getPathname(path);
     var queryString = getQueryString(path);
     var query = queryString ? this.parseQueryString(queryString) : null;
-    return new Location(path, pathname, query, {...state, ...entry}, navigationType);
+    return new Location(pathname, query, {...state, ...entry}, navigationType);
   }
 
 }

--- a/modules/Location.js
+++ b/modules/Location.js
@@ -12,7 +12,8 @@ class Location {
     return object instanceof Location;
   }
 
-  constructor(pathname='/', query=null, state=null, navigationType=NavigationTypes.POP) {
+  constructor(path='/', pathname=path, query=null, state=null, navigationType=NavigationTypes.POP) {
+    this.path = path;
     this.pathname = pathname;
     this.query = query;
     this.state = state;

--- a/modules/Location.js
+++ b/modules/Location.js
@@ -12,8 +12,7 @@ class Location {
     return object instanceof Location;
   }
 
-  constructor(path='/', pathname=path, query=null, state=null, navigationType=NavigationTypes.POP) {
-    this.path = path;
+  constructor(pathname='/', query=null, state=null, navigationType=NavigationTypes.POP) {
     this.pathname = pathname;
     this.query = query;
     this.state = state;

--- a/modules/MemoryHistory.js
+++ b/modules/MemoryHistory.js
@@ -50,7 +50,7 @@ class MemoryHistory extends History {
     var path = entry.path;
     var key = entry.key;
 
-    super.setup(path, {key, current: this.current});
+    super.setup(path, { key, current: this.current });
   }
 
   _createEntry(object) {
@@ -69,14 +69,14 @@ class MemoryHistory extends History {
     this.current += 1;
     this.entries = this.entries.slice(0, this.current).concat([{ key, path }]);
 
-    return {key, current: this.current};
+    return { key, current: this.current };
   }
 
   // http://www.w3.org/TR/2011/WD-html5-20110113/history.html#dom-history-replacestate
   replace(path, key) {
     this.entries[this.current] = { key, path };
 
-    return {key, current: this.current};
+    return { key, current: this.current };
   }
 
   readState(key) {
@@ -100,7 +100,7 @@ class MemoryHistory extends History {
     this.current += n;
     var currentEntry = this.entries[this.current];
 
-    this.handlePop(currentEntry.path, {key: currentEntry.key, current: this.current});
+    this.handlePop(currentEntry.path, { key: currentEntry.key, current: this.current });
   }
 
   canGo(n) {

--- a/modules/__tests__/scrollManagement-test.js
+++ b/modules/__tests__/scrollManagement-test.js
@@ -60,11 +60,15 @@ describe('Scroll management', function () {
     ];
 
     function execNextStep() {
-      try {
-        steps.shift().apply(this, arguments);
-      } catch (error) {
-        done(error);
+      if (steps.length < 1){
+        done();
+        return;
       }
+
+      // Give the DOM a little time to reflect the hashchange.
+      setTimeout(() => {
+        steps.shift().call(this);
+      }, 10);
     }
 
     var history = new HashHistory({ queryKey: true });


### PR DESCRIPTION
This PR attempts to fix/improve the current Histories in a couple of ways:

1. Store state in `sessionStorage` based on `key` with `BrowserHistory` as well
2. Normalize behavior in terms of creating new history entries (part of #1031)
3. Fix a bug with `HashHistory` ignoring hashChange after transitioning to the same path that's currently active

While trying to do all those things, I felt like the History classes needed some refactoring. So `History` is now responsible for managing keys and state, and performing navigations.

Subclasses now have to do the following:

1. Implement `push(path, key): entry` and `replace(path, key): entry` instead of `pushState` and `replaceState`. These should only apply the given path (and optionally key) to whatever they're working with, but not call `this._notifyChange` or set `this.location`
2. For pop events, instead of setting up `this.location` and calling `this._notifyChange` themselves, they now have to call `this.handlePop(path, entry)`
3. Initial location is now set in `setup()` by calling `super.setup(path, entry)`, after which `this.location` can be safely read

The (optional) `entry` object will be merged into `state`, allowing subclasses to pass arbitrary information to the user based on the current entry. It's also used to signal `History` that `key` (and thus `state`) is supported. In the future, we could add additional props like that, such as `current` and `length`.

Also, I had to change the scrolling test to include timeouts; otherwise, the hashchange event timings would have been off, I think. Not sure why I couldn't reproduce this with the old code (not exactly fun to debug :smile:). Anyway, as far as I can tell, the scrolling didn't even work before and the test passed due to native browser scrolling (which is still the case..).

Let me know what you think; I'm also open to applying these changes to the old API if you don't agree with them.

@mjackson @ryanflorence @gaearon