### PR TITLE
Move transitionTo, replaceWith to history

### DIFF
--- a/modules/History.js
+++ b/modules/History.js
@@ -1,5 +1,5 @@
 import invariant from 'invariant';
-import { getPathname, getQueryString, parseQueryString } from './URLUtils';
+import { getPathname, getQueryString, parseQueryString, stringifyQuery, makePath } from './URLUtils';
 import Location from './Location';
 
 var RequiredHistorySubclassMethods = [ 'pushState', 'replaceState', 'go' ];
@@ -29,6 +29,7 @@ class History {
     }, this);
 
     this.parseQueryString = options.parseQueryString || parseQueryString;
+    this.stringifyQuery = options.stringifyQuery || stringifyQuery;
     this.changeListeners = [];
     this.location = null;
   }
@@ -46,6 +47,27 @@ class History {
     this.changeListeners = this.changeListeners.filter(function (li) {
       return li !== listener;
     });
+  }
+
+  /**
+   * Returns a full URL path from the given pathname and query.
+   */
+  makePath(pathname, query) {
+    return makePath(pathname, query);
+  }
+
+  /**
+   * Pushes a new Location onto the history stack.
+   */
+  transitionTo(pathname, query, state=null) {
+    this.pushState(state, this.makePath(pathname, query));
+  }
+
+  /**
+   * Replaces the current Location on the history stack.
+   */
+  replaceWith(pathname, query, state=null) {
+    this.replaceState(state, this.makePath(pathname, query));
   }
 
   back() {

--- a/modules/RouterContextMixin.js
+++ b/modules/RouterContextMixin.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import invariant from 'invariant';
-import { stripLeadingSlashes, stringifyQuery } from './URLUtils';
+import { stripLeadingSlashes, makePath } from './URLUtils';
 
 var { func, object } = React.PropTypes;
 
@@ -31,16 +31,6 @@ function queryIsActive(query, activeQuery) {
 
 var RouterContextMixin = {
 
-  propTypes: {
-    stringifyQuery: func.isRequired
-  },
-
-  getDefaultProps() {
-    return {
-      stringifyQuery
-    };
-  },
-
   childContextTypes: {
     router: object.isRequired
   },
@@ -55,15 +45,7 @@ var RouterContextMixin = {
    * Returns a full URL path from the given pathname and query.
    */
   makePath(pathname, query) {
-    if (query) {
-      if (typeof query !== 'string')
-        query = this.props.stringifyQuery(query);
-
-      if (query !== '')
-        return pathname + '?' + query;
-    }
-
-    return pathname;
+    return makePath(pathname, query);
   },
 
   /**
@@ -79,7 +61,7 @@ var RouterContextMixin = {
 
     return path;
   },
- 
+
   /**
    * Pushes a new Location onto the history stack.
    */
@@ -91,7 +73,7 @@ var RouterContextMixin = {
       'Router#transitionTo is client-side only (needs history)'
     );
 
-    history.pushState(state, this.makePath(pathname, query));
+    history.transitionTo(pathname, query, state);
   },
 
   /**
@@ -105,7 +87,7 @@ var RouterContextMixin = {
       'Router#replaceWith is client-side only (needs history)'
     );
 
-    history.replaceState(state, this.makePath(pathname, query));
+    history.replaceWith(pathname, query, state);
   },
 
   /**
@@ -137,7 +119,7 @@ var RouterContextMixin = {
   goForward() {
     this.go(1);
   },
- 
+
   /**
    * Returns true if a <Link> to the given pathname/query combination is
    * currently active.

--- a/modules/URLUtils.js
+++ b/modules/URLUtils.js
@@ -7,6 +7,18 @@ export function stringifyQuery(query) {
   return qs.stringify(query, { arrayFormat: 'brackets' });
 }
 
+export function makePath(pathname, query) {
+  if (query) {
+    if (typeof query !== 'string')
+      query = stringifyQuery(query);
+
+    if (query !== '')
+      return pathname + '?' + query;
+  }
+
+  return pathname;
+}
+
 var queryMatcher = /\?([\s\S]*)$/;
 
 export function getPathname(path) {


### PR DESCRIPTION
This makes integration with flux much easier. If you have access to the history instance, you can invoke transitions with flux actions like this:

```javascript
import history from './history';

export function loginSuccess(user) {
    return dispatch => {
        dispatch({
           user: user,
           type: 'loginSuccess'
       });
       history.transitionTo('/dashboard');
    };
}
```

A custom `stringifyQuery` can be passed to the History constructor like:

```javascript
const history = new HashHistory({ stringifyQuery: myStringifyQuery });
```