### PR TITLE
DOCS: Declaring history outside of render

### DIFF
--- a/doc/00 Guides/0 Overview.md
+++ b/doc/00 Guides/0 Overview.md
@@ -138,10 +138,13 @@ var App = React.createClass({
   }
 });
 
+// Declare the history outside of the `render` function.
+var history = new HashHistory();
+
 // Finally we render a `Router` component with some `Route`s, it'll do all
 // the fancy routing stuff for us.
 React.render((
-  <Router history={new HashHistory}>
+  <Router history={history}>
     <Route path="/" component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}/>
@@ -153,6 +156,7 @@ React.render((
 If you're not digging the JSX route config you can use plain objects:
 
 ```js
+var history = new HashHistory();
 var routes = {
   path: '/',
   component: App,
@@ -162,7 +166,7 @@ var routes = {
   ]
 };
 
-React.render(<Router history={new HashHistory} children={routes}/>, document.body);
+React.render(<Router history={history} children={routes}/>, document.body);
 ```
 
 Adding more UI
@@ -190,8 +194,9 @@ var Inbox = React.createClass({
   }
 });
 
+var history = new HashHistory();
 React.render((
-  <Router history={new HashHistory}>
+  <Router history={history}>
     <Route component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}>

--- a/doc/03 History/BrowserHistory.md
+++ b/doc/03 History/BrowserHistory.md
@@ -44,9 +44,10 @@ Example
 ```js
 import { Router } from 'react-router';
 import BrowserHistory from 'react-router/lib/BrowserHistory';
+var history = new BrowserHistory();
 
 React.render((
-  <Router history={new BrowserHistory}>
+  <Router history={ history }>
     {/* ... */}
   </Router>
 ), document.body);

--- a/doc/03 History/HashHistory.md
+++ b/doc/03 History/HashHistory.md
@@ -34,9 +34,10 @@ Normal usage
 ```js
 import { Router } from 'react-router';
 import HashHistory from 'react-router/lib/HashHistory';
+var history = new HashHistory();
 
 React.render((
-  <Router history={new HashHistory}>
+  <Router history={ history }>
     {/* ... */}
   </Router>
 ), document.body);


### PR DESCRIPTION
tl;dr: people should not do
```js
React.render(<Router history={ new HashHistory } />, ...);
```
but create a "singleton" history instance and call it with
```js
var history = new HashHistory();
React.render(<Router history={ history } />, ...);
```

this PR fixes the confusion made while integrating some libraries, like [microcosm](https://github.com/vigetlabs/microcosm/) and [react-hot-loader](https://github.com/gaearon/react-hot-loader) stated [here](https://github.com/rackt/react-router/issues/1418#issuecomment-115391528).