### PR TITLE
fix document error about how to call HashHistory

### DIFF
--- a/doc/00 Guides/0 Overview.md
+++ b/doc/00 Guides/0 Overview.md
@@ -141,7 +141,7 @@ var App = React.createClass({
 // Finally we render a `Router` component with some `Route`s, it'll do all
 // the fancy routing stuff for us.
 React.render((
-  <Router history={new HashHistory}>
+  <Router history={new HashHistory({})}>
     <Route path="/" component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}/>
@@ -162,7 +162,7 @@ var routes = {
   ]
 };
 
-React.render(<Router history={new HashHistory} children={routes}/>, document.body);
+React.render(<Router history={new HashHistory({})} children={routes}/>, document.body);
 ```
 
 Adding more UI
@@ -191,7 +191,7 @@ var Inbox = React.createClass({
 });
 
 React.render((
-  <Router history={new HashHistory}>
+  <Router history={new HashHistory({})}>
     <Route component={App}>
       <Route path="about" component={About}/>
       <Route path="inbox" component={Inbox}>


### PR DESCRIPTION
Hi,all:

I fix a document error about how to call HashHistory in document.

`{new HashHistory}` will cause an error when we use webpack, `{new HashHistory({})}` should be better.
```
97:30  error    Missing '()' invoking a constructor  new-parens
```

