### PR TITLE
Clean up docs (grammar and code style)

### DIFF
--- a/doc/00 Guides/0 Overview.md
+++ b/doc/00 Guides/0 Overview.md
@@ -41,7 +41,7 @@ var App = React.createClass({
         </ul>
         <Child/>
       </div>
-    )
+    );
   }
 });
 
@@ -134,7 +134,7 @@ var App = React.createClass({
         */}
         {this.props.children}
       </div>
-    )
+    );
   }
 });
 
@@ -221,7 +221,7 @@ var Message = React.createClass({
     var id = this.props.params.id;
     fetchMessage(id, function (err, message) {
       this.setState({ message: message });
-    })
+    });
   },
   // ...
 });

--- a/doc/00 Guides/Advanced Usage.md
+++ b/doc/00 Guides/Advanced Usage.md
@@ -1,6 +1,6 @@
 React Router is great for small sites like [React.js
-Training][shameless] ("React Router brought to you by ...") but its
-built with websites like [facebook][fb] and [twitter][t] in mind, too.
+Training][shameless] ("React Router brought to you by ...") but it's
+built with websites like [Facebook][fb] and [Twitter][t] in mind, too.
 
 The biggest concern for large apps is the amount of JavaScript required
 to boot the app. Large apps should download only the JavaScript required
@@ -8,13 +8,13 @@ to render the current view. Some people call this "code splitting", you
 split your code up into multiple bundles that are loaded on-demand as
 the visitor navigates around.
 
-Its important that changes deep down in the application don't require
+It's important that changes deep down in the application don't require
 changes all the way up top. Adding a route to the photo viewer should
 not affect the size of the initial JavaScript bundle the user downloads.
 Neither should it cause merge conflicts as multiple teams have their
 fingers in the same, big route configuration file.
 
-Your router is the perfect place to handle code splitting: its
+Your router is the perfect place to handle code splitting: it's
 responsible for setting up your views.
 
 React Router does all of its path matching and component resolving

--- a/doc/00 Guides/Advanced Usage.md
+++ b/doc/00 Guides/Advanced Usage.md
@@ -43,14 +43,14 @@ module.exports = {
         require('./routes/Announcements'),
         require('./routes/Assignments'),
         require('./routes/Grades'),
-      ])
-    })
+      ]);
+    });
   },
 
   getComponents (cb) {
     require.ensure([], (require) => {
       cb(null, require('./components/Course'))
-    })
+    });
   }
 };
 ```

--- a/doc/00 Guides/Server Rendering.md
+++ b/doc/00 Guides/Server Rendering.md
@@ -3,7 +3,7 @@ browser. The primary difference is that while on the client we can do
 asynchronous work *after* rendering, on the server we have to do that
 work *before* rendering, like path matching and data fetching.
 
-We'll start with the client since its pretty simple. The only
+We'll start with the client since it's pretty simple. The only
 interesting thing is that we are getting some initial data from the
 server render to ensure that the first client render markup matches the
 the markup from the server render. Without the initial data, the markup

--- a/doc/00 Guides/Server Rendering.md
+++ b/doc/00 Guides/Server Rendering.md
@@ -59,7 +59,7 @@ function renderFullPage(html, initialData) {
     </script>
   </body>
 </html>
-`
+`;
 }
 ```
 

--- a/doc/01 Route Configuration/Plain Route.md
+++ b/doc/01 Route Configuration/Plain Route.md
@@ -48,10 +48,12 @@ var myRoute = {
   path: 'picture/:id',
   getChildRoutes (state, cb) {
     // state gets passed to `getChildRoutes`
-    if (state && state.fromDashboard)
+    if (state && state.fromDashboard) {
       cb(null, [dashboardPictureRoute])
-    else
+    }
+    else {
       cb(null, [pictureRoute])
+    }
   }
 };
 ```

--- a/doc/02 Components/0 Router.md
+++ b/doc/02 Components/0 Router.md
@@ -43,7 +43,7 @@ By default, this function uses `qs.stringify(query, { arrayFormat: 'brackets' })
 // default behavior
 function createElement(Component, props) {
   // make sure you pass all the props in!
-  return <Component {...props}/>
+  return <Component {...props}/>;
 }
 
 // maybe you're using something like Relay

--- a/doc/02 Components/Route Component.md
+++ b/doc/02 Components/Route Component.md
@@ -1,5 +1,5 @@
 A user-defined component given to a `Route` as the `component` prop. The
-router will inject properties into your component when its rendered.
+router will inject properties into your component when it's rendered.
 
 Injected Props
 --------------

--- a/doc/03 History/MemoryHistory.md
+++ b/doc/03 History/MemoryHistory.md
@@ -1,5 +1,5 @@
 `MemoryHistory` is a [history][Histories] implementation that does not
-read and write state to the address bar of the browser. Its useful for
+read and write state to the address bar of the browser. It's useful for
 testing and running React Router in persistent environments that don't
 have URLs.
 

--- a/doc/04 Mixins/TransitionHook.md
+++ b/doc/04 Mixins/TransitionHook.md
@@ -27,9 +27,11 @@ var SignupForm = React.createClass({
   mixins: [ TransitionHook ],
 
   routerWillLeave (nextState, router) {
-    if (this.formIsHalfFilledOut())
-      if (!prompt("You sure you want to leave?"))
+    if (this.formIsHalfFilledOut()) {
+      if (!prompt("You sure you want to leave?")) {
         router.cancelTransition();
+      }
+    }
   },
 
   // ...

--- a/formatter.js
+++ b/formatter.js
@@ -1,0 +1,41 @@
+var About = React.createClass({/*...*/});
+var Inbox = React.createClass({/*...*/});
+var Home = React.createClass({/*...*/});
+
+var App = React.createClass({
+  getInitialState () {
+    return {
+      route: window.location.hash.substr(1)
+    };
+  },
+
+  componentDidMount () {
+    window.addEventListener('hashchange', () => {
+      this.setState({
+        route: window.location.hash.substr(1)
+      });
+    });
+  },
+
+  render () {
+    var Child;
+    switch (this.state.route) {
+      case '/about': Child = About; break;
+      case '/inbox': Child = Inbox; break;
+      default:      Child = Home;
+    }
+
+    return (
+      <div>
+      <h1>App</h1>
+      <ul>
+      <li><a href="#/about">About</a></li>
+    <li><a href="#/inbox">Inbox</a></li>
+    </ul>
+    <Child/>
+    </div>
+  )
+  }
+});
+
+React.render(<App />, document.body);


### PR DESCRIPTION
This PR fixes the following in the docs:

- grammar mistakes (there might be more, I haven't read through all of the docs yet)
- code style (add missing semicolons, remove shorthand if-statements)

I noticed the source code also uses a mix of regular and shorthand if-statements. The doc fixes are in a separate commit, so it's easy to pull those out if you'd rather keep the shorthand version.