### PR TITLE
Fixes false positives in Link isActive checks

### DIFF
--- a/modules/RouterContextMixin.js
+++ b/modules/RouterContextMixin.js
@@ -1,18 +1,11 @@
 import React from 'react';
 import invariant from 'invariant';
-import { stripLeadingSlashes, stringifyQuery } from './URLUtils';
+import { stripLeadingSlashes, stringifyQuery, doesPathMatch } from './URLUtils';
 
 var { func, object } = React.PropTypes;
 
 function pathnameIsActive(pathname, activePathname) {
-  if (stripLeadingSlashes(activePathname).indexOf(stripLeadingSlashes(pathname)) === 0)
-    return true; // This quick comparison satisfies most use cases.
-
-  // TODO: Implement a more stringent comparison that checks
-  // to see if the pathname matches any routes (and params)
-  // in the currently active branch.
-
-  return false;
+  return doesPathMatch(pathname, activePathname);
 }
 
 function queryIsActive(query, activeQuery) {

--- a/modules/URLUtils.js
+++ b/modules/URLUtils.js
@@ -26,6 +26,30 @@ export function isAbsolutePath(path) {
   return typeof path === 'string' && path.charAt(0) === '/';
 }
 
+/**
+ * Determines whether or not a path 'matches' part of another path.
+ * e.g., if /users matches /users/5/profile
+ */
+export function doesPathMatch(path, compare) {
+  var strippedPath = stripLeadingSlashes(path);
+  var strippedPathCompare = stripLeadingSlashes(compare);
+
+  if (strippedPath === "")
+    return true;
+
+  var splitMatcher = /([/?#]+)/;
+  var splitPath = strippedPath.split(splitMatcher);
+  var splitPathCompare = strippedPathCompare.split(splitMatcher);
+
+  for (var i = 0; i < splitPath.length; i++) {
+    if (splitPath[i].length && splitPath[i] !== splitPathCompare[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -80,12 +80,14 @@ describe('A <Link>', function () {
           <div>
             <Link to="/hello/michael">Michael</Link>
             <Link to="/hello/ryan">Ryan</Link>
+            <Link to="/hello/ryan%20florence">Ryan Florence</Link>
+            <Link to="/hello">Hello</Link>
           </div>
         );
       }
     });
 
-    it('is active when its params match', function (done) {
+    it('is active when its params match all path segments', function (done) {
       render((
         <Router history={new MemoryHistory('/hello/michael')}>
           <Route path="/" component={App}>
@@ -99,9 +101,37 @@ describe('A <Link>', function () {
       });
     });
 
+    it('is active when its params match parent path segments', function (done) {
+      render((
+        <Router history={new MemoryHistory('/hello/michael')}>
+          <Route path="/" component={App}>
+            <Route path="/hello/:name" component={Hello}/>
+          </Route>
+        </Router>
+      ), div, function () {
+        var a = div.querySelectorAll('a')[3];
+        expect(a.className.trim()).toEqual('active');
+        done();
+      });
+    });
+
     it('is not active when its params do not match', function (done) {
       render((
         <Router history={new MemoryHistory('/hello/michael')}>
+          <Route path="/" component={App}>
+            <Route path="/hello/:name" component={Hello}/>
+          </Route>
+        </Router>
+      ), div, function () {
+        var a = div.querySelectorAll('a')[1];
+        expect(a.className.trim()).toEqual('');
+        done();
+      });
+    });
+
+    it('is not active when its params match only an initial part of a segment', function (done) {
+      render((
+        <Router history={new MemoryHistory('/hello/ryan%20florence')}>
           <Route path="/" component={App}>
             <Route path="/hello/:name" component={Hello}/>
           </Route>

--- a/modules/__tests__/URLUtils-test.js
+++ b/modules/__tests__/URLUtils-test.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { getPathname, getQueryString, getParamNames, getParams, formatPattern } from '../URLUtils';
+import { getPathname, getQueryString, getParamNames, getParams, formatPattern, doesPathMatch } from '../URLUtils';
 
 describe('getPathname', function () {
   it('returns the pathname portion of a path', function () {
@@ -29,6 +29,52 @@ describe('getParamNames', function () {
   describe('when a pattern has a *', function () {
     it('uses the name "splat"', function () {
       expect(getParamNames('/files/*.jpg')).toEqual([ 'splat' ]);
+    });
+  });
+});
+
+describe('doesPathMatch', function () {
+  describe('when a path is the root', function () {
+    it('matches everything', function () {
+      expect(doesPathMatch('/', '/')).toEqual(true);
+      expect(doesPathMatch('/', '/users')).toEqual(true);
+      expect(doesPathMatch('/', '/users/5')).toEqual(true);
+      expect(doesPathMatch('/', '/users/5/profile')).toEqual(true);
+    });
+  });
+  describe('when a path has varying levels', function () {
+    it('returns true for exact matches', function () {
+      expect(doesPathMatch('/users', '/users')).toEqual(true);
+      expect(doesPathMatch('/users/', '/users/5')).toEqual(true);
+      expect(doesPathMatch('/users/5', '/users/5')).toEqual(true);
+      expect(doesPathMatch('/users/5/profile', '/users/5/profile')).toEqual(true);
+    });
+    it('returns false for non-matches', function () {
+      expect(doesPathMatch('/users', '/')).toEqual(false);
+      expect(doesPathMatch('/users/5', '/users/55')).toEqual(false);
+      expect(doesPathMatch('/users/', '/users')).toEqual(false);
+      expect(doesPathMatch('/users/john', '/users/john smith')).toEqual(false);
+      expect(doesPathMatch('/projects', '/users')).toEqual(false);
+      expect(doesPathMatch('/projects/5', '/users/5')).toEqual(false);
+      expect(doesPathMatch('/projects/5/info', '/users/5/info')).toEqual(false);
+    });
+  });
+  describe('when a path has query/hash params', function () {
+    it('returns true for exact matches', function () {
+      expect(doesPathMatch('/users?id=5', '/users?id=5')).toEqual(true);
+      expect(doesPathMatch('/users?id=5#heading', '/users?id=5#heading')).toEqual(true);
+      expect(doesPathMatch('/users/profile?id=5', '/users/profile?id=5')).toEqual(true);
+    });
+    it('returns true for partial matches', function () {
+      expect(doesPathMatch('/users', '/users?id=5')).toEqual(true);
+      expect(doesPathMatch('/users', '/users/profile?id=5')).toEqual(true);
+      expect(doesPathMatch('/users?id=5', '/users?id=5#heading')).toEqual(true);
+    });
+    it('returns false for non-matches', function () {
+      expect(doesPathMatch('/users?id=5', '/users?id=55')).toEqual(false);
+      expect(doesPathMatch('/users?id=5', '/users')).toEqual(false);
+      expect(doesPathMatch('/users?id=5', '/')).toEqual(false);
+      expect(doesPathMatch('/users?id', '/users/id')).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
This is intended to fix https://github.com/rackt/react-router/issues/1441.

It's possible that you have better ideas in mind for solving this, so feel free to disregard this PR if that's the case. 

I pulled the path matching code into URLUtils so that they're easier to test. Maybe it's possible to re-use some of the existing pattern matching, but I didn't see an easy way.

