### PR TITLE
Show the stack trace of the original error intercepted during Transition. 

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -185,8 +185,8 @@ var Router = React.createClass({
     if (this.props.onError) {
       this.props.onError.call(this, error);
     } else {
-      // Throw errors by default so we don't silently swallow them!
-      throw error; // This error probably originated in getChildRoutes or getComponents.
+      var msg = error.stack ? error.stack : 'An error ocurred (probably originated in a transition hook)';
+      throw new Error(msg); // This error probably originated in a transition hook.
     }
   },
 


### PR DESCRIPTION
The `handleError` currently gives no clue about where the error occurred. 