### PR TITLE
Specifically include this.props.children in App component in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,17 @@ What's it look like?
 import { Router, Route } from 'react-router';
 import { history } from 'react-router/lib/BrowserHistory';
 
-var App = React.createClass({/*...*/});
+var App = React.createClass({
+  render() {
+    return (
+      <div>
+        <h1>Site Title</h1>
+        {this.props.children}
+      </div>
+    );
+  }
+});
+
 var About = React.createClass({/*...*/});
 // etc.
 


### PR DESCRIPTION
As a newcomer to react-router, it took me longer than I'd like to admit that my main/app component needs to include `this.props.children` in order for my links to work & render properly.  I was thrown off by the lack of inclusion of it in the readme.  I'm hoping this will help prevent others from making the same mistake. :)