### PR TITLE
fix missing router error in Link

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -75,7 +75,7 @@ export var Link = React.createClass({
     var { to, query } = this.props;
 
     var props = Object.assign({}, this.props, {
-      href: router.makeHref(to, query),
+      href: router && router.makeHref(to, query),
       onClick: this.handleClick
     });
 


### PR DESCRIPTION
Here is simple solution for bug #1513 of missing `router` field in context of `Link`. Critical for unit testing.