### PR TITLE
Trigger click if button argument is undefined

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -3,7 +3,7 @@ import React from 'react';
 var { object, string, func } = React.PropTypes;
 
 function isLeftClickEvent(event) {
-  return event.button === 0;
+  return event.button === undefined || event.button === 0;
 }
 
 function isModifiedEvent(event) {

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -279,7 +279,7 @@ describe('A <Link>', function () {
 
       var steps = [
         function () {
-          click(div.querySelector('a'), { button: 0 });
+          click(div.querySelector('a'));
         },
         function () {
           expect(div.innerHTML).toMatch(/Hello/);


### PR DESCRIPTION
When testing a component it's easy to forget to pass the event data to `click()`

If it's left out, regular clicks would still trigger, but ReactRouter Links would not.

Suggestions are welcome if I should test it better or anything.  I didn't want to document this, since it's intended just as a convenience in case someone (like me) forgets to pass event data. to `React.addons.TestUtils.Simulate.click`

