### PR TITLE
Change query default to empty object

### DIFF
--- a/modules/History.js
+++ b/modules/History.js
@@ -225,7 +225,7 @@ class History {
   _createLocation(path, state, entry, navigationType) {
     var pathname = getPathname(path);
     var queryString = getQueryString(path);
-    var query = queryString ? this.parseQueryString(queryString) : null;
+    var query = this.parseQueryString(queryString);
     return new Location(pathname, query, {...state, ...entry}, navigationType);
   }
 

--- a/modules/Location.js
+++ b/modules/Location.js
@@ -12,7 +12,7 @@ class Location {
     return object instanceof Location;
   }
 
-  constructor(pathname='/', query=null, state=null, navigationType=NavigationTypes.POP) {
+  constructor(pathname='/', query={}, state=null, navigationType=NavigationTypes.POP) {
     this.pathname = pathname;
     this.query = query;
     this.state = state;


### PR DESCRIPTION
When using location.query you no longer need to check if location.query is null before accessing a property.