### PR TITLE
avoid unnecessary work

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -64,6 +64,11 @@ export var Link = React.createClass({
     if (clickResult === false || event.defaultPrevented === true)
       allowTransition = false;
 
+    if (this.context.router.state.location.pathname === this.props.to
+        &&
+        this.context.router.state.location.query == this.props.query) // == b/c query may be null / undefined
+      allowTransition = false;
+
     event.preventDefault();
 
     if (allowTransition)


### PR DESCRIPTION
It seems to me that when someone clicks on a Link, if the current router state is the same as what the resulting router state would be after the Link is done transitioning, we should just disallow the transition to begin with.

This helps to avoid unnecessary flickering, particularly in a flux environment.