### PR TITLE
Update link to new official repository for React-Router Bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Related Modules
 
 - [rnr-constrained-route](https://github.com/bjyoungblood/rnr-constrained-route) - validate paths
   and parameters on route handlers.
-- [react-router-bootstrap](https://github.com/mtscout6/react-router-bootstrap) - Integration with [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap) components.
+- [react-router-bootstrap](https://github.com/react-bootstrap/react-router-bootstrap) - Integration with [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap) components.
 - [react-router-proxy-loader](https://github.com/odysseyscience/react-router-proxy-loader) - A Webpack loader to dynamically load react-router components on-demand
 
 Contributing


### PR DESCRIPTION
Old link, https://github.com/mtscout6/react-router-bootstrap, points to the new repository.