### PR TITLE
[fixed #1441] isActive false positive when URL not finished

### DIFF
--- a/modules/RouterContextMixin.js
+++ b/modules/RouterContextMixin.js
@@ -5,14 +5,25 @@ import { stripLeadingSlashes, stringifyQuery } from './URLUtils';
 var { func, object } = React.PropTypes;
 
 function pathnameIsActive(pathname, activePathname) {
-  if (stripLeadingSlashes(activePathname).indexOf(stripLeadingSlashes(pathname)) === 0)
-    return true; // This quick comparison satisfies most use cases.
+  pathname = stripLeadingSlashes(pathname);
+  activePathname = stripLeadingSlashes(activePathname);
 
-  // TODO: Implement a more stringent comparison that checks
-  // to see if the pathname matches any routes (and params)
-  // in the currently active branch.
+  // perfect match
+  if (pathname === activePathname) {
+    return true;
+  }
 
-  return false;
+  // starts with your path?
+  if (activePathname.indexOf(pathname) !== 0) {
+    return false;
+  }
+
+  // eliminate false-positive when the path section was not finished
+  if (activePathname.charAt(pathname.length) !== '/') {
+    return false;
+  }
+
+  return true;
 }
 
 function queryIsActive(query, activeQuery) {
@@ -79,7 +90,7 @@ var RouterContextMixin = {
 
     return path;
   },
- 
+
   /**
    * Pushes a new Location onto the history stack.
    */
@@ -137,7 +148,7 @@ var RouterContextMixin = {
   goForward() {
     this.go(1);
   },
- 
+
   /**
    * Returns true if a <Link> to the given pathname/query combination is
    * currently active.


### PR DESCRIPTION
This is fixing a huge bug for the isActive. If I had a path starting with /hell and another by /hello, isActive would think /hello is active when I am on the /hell URL. This is perfectly fixed now :)

I wasn't able to write unit tests because `karma start` was crashing for me. I would get this:
(Looks like Travis was having the same error before my PR)

```
WARN [preprocess]: Can not load "webpack"!
  TypeError: Object [object Object] has no method 'refreshFiles'
    at Plugin.notifyKarmaAboutChanges (/var/git/thereactivestack/react-router/node_modules/karma-webpack/index.js:108:15)
    at Plugin.<anonymous> (/var/git/thereactivestack/react-router/node_modules/karma-webpack/index.js:72:9)
    at Tapable.applyPlugins (/var/git/thereactivestack/react-router/node_modules/webpack/node_modules/tapable/lib/Tapable.js:26:37)
    at Watching._done (/var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:78:17)
    at Watching.<anonymous> (/var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:61:18)
    at Tapable.emitRecords (/var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:281:37)
    at Watching.<anonymous> (/var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:58:19)
    at /var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:274:11
    at Tapable.applyPluginsAsync (/var/git/thereactivestack/react-router/node_modules/webpack/node_modules/tapable/lib/Tapable.js:60:69)
    at Tapable.afterEmit (/var/git/thereactivestack/react-router/node_modules/webpack/lib/Compiler.js:271:8)
INFO [karma]: Karma v0.12.37 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
INFO [Chrome 44.0.2403 (Linux 0.0.0)]: Connected on socket k3-vXGcIA8yu4S8lLBYy with id 79713155
Chrome 44.0.2403 (Linux 0.0.0) ERROR
  Uncaught ReferenceError: require is not defined
  at /var/git/thereactivestack/react-router/tests.webpack.js:1
Chrome 44.0.2403 (Linux 0.0.0): Executed 0 of 0 ERROR (0.047 secs / 0 secs)
```