### PR TITLE
Fixing invalid EcmaScript 2015 code.

### DIFF
--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -4,24 +4,14 @@ import History from './History';
 
 var { func, object, arrayOf, instanceOf, oneOfType, element } = React.PropTypes;
 
-function falsy(props, propName, componentName) {
+export function falsy(props, propName, componentName) {
   if (props[propName])
     return new Error(`<${componentName}> should not have a "${propName}" prop`);
 }
 
-var component = func;
-var components = oneOfType([ component, object ]);
-var history = instanceOf(History);
-var location = instanceOf(Location);
-var route = oneOfType([ object, element ]);
-var routes = oneOfType([ route, arrayOf(route) ]);
-
-module.exports = {
-  falsy,
-  component,
-  components,
-  history,
-  location,
-  route,
-  routes
-};
+export var component = func;
+export var components = oneOfType([ component, object ]);
+export var history = instanceOf(History);
+export var location = instanceOf(Location);
+export var route = oneOfType([ object, element ]);
+export var routes = oneOfType([ route, arrayOf(route) ]);

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -7,8 +7,9 @@ import { getState, getTransitionHooks, getComponents, getRouteParams, createTran
 import { routes, component, components, history, location } from './PropTypes';
 import RouterContextMixin from './RouterContextMixin';
 import ScrollManagementMixin from './ScrollManagementMixin';
-import { isLocation } from './Location';
+import Location from './Location';
 import Transition from './Transition';
+var isLocation = Location.isLocation;
 
 var { arrayOf, func, object } = React.PropTypes;
 


### PR DESCRIPTION
Hello,
I am opening this PR to fix the following issues in the EcmaScript 2015 code of react-router:

- Using `module.exports` is only valid when using the CommonJS module format, but if you plan to transpile your code to a different module format, it will not work.

- `import { isLocation }` is only valid if `isLocation` was exported with the `export` keyword, it does not look inside the default export. Here also, it may work depending on the module format you transpile your code to.