### PR TITLE
Fixed onEnter callback on JSX routes

### DIFF
--- a/modules/createRoutesFromReactChildren.js
+++ b/modules/createRoutesFromReactChildren.js
@@ -24,10 +24,11 @@ function createRouteOptions(props) {
   var options = assign({}, props);
   var handler = options.handler;
 
-  if (handler) {
+  if (handler.willTransitionTo)
     options.onEnter = handler.willTransitionTo;
+
+  if (handler.willTransitionFrom)
     options.onLeave = handler.willTransitionFrom;
-  }
 
   return options;
 }


### PR DESCRIPTION
This sets the onEnter function only when it's defined in the handler, otherwise it keeps the callback defined in the JSX (also works with onLeave)