### PR TITLE
Separate router logic from rendering logic

### DIFF
--- a/modules/ActiveMixin.js
+++ b/modules/ActiveMixin.js
@@ -1,68 +1,7 @@
-import { matchPattern } from './PatternUtils';
-
-/**
- * Returns true if a route and params that match the given
- * pathname are currently active.
- */
-function pathnameIsActive(pathname, activePathname, activeRoutes, activeParams) {
-  if (pathname === activePathname || activePathname.indexOf(pathname + '/') === 0)
-    return true;
-
-  var route, pattern;
-  var basename = '';
-  for (var i = 0, len = activeRoutes.length; i < len; ++i) {
-    route = activeRoutes[i];
-    pattern = route.path || '';
-
-    if (pattern.indexOf('/') !== 0)
-      pattern = basename.replace(/\/*$/, '/') + pattern; // Relative paths build on the parent's path.
-
-    var { remainingPathname, paramNames, paramValues } = matchPattern(pattern, pathname);
-
-    if (remainingPathname === '') {
-      return paramNames.every(function (paramName, index) {
-        return String(paramValues[index]) === String(activeParams[paramName]);
-      });
-    }
-
-    basename = pattern;
-  }
-
-  return false;
-}
-
-/**
- * Returns true if all key/value pairs in the given query are
- * currently active.
- */
-function queryIsActive(query, activeQuery) {
-  if (activeQuery == null)
-    return query == null;
-
-  if (query == null)
-    return true;
-
-  for (var p in query)
-    if (query.hasOwnProperty(p) && String(query[p]) !== String(activeQuery[p]))
-      return false;
-
-  return true;
-}
-
 var ActiveMixin = {
 
-  /**
-   * Returns true if a <Link> to the given pathname/query combination is
-   * currently active.
-   */
-  isActive(pathname, query) {
-    var { location, routes, params } = this.state;
-
-    if (location == null)
-      return false;
-
-    return pathnameIsActive(pathname, location.pathname, routes, params) &&
-      queryIsActive(query, location.query);
+  isActive() {
+    return this.router.isActive.apply(this.router, arguments);
   }
 
 };

--- a/modules/ActiveUtils.js
+++ b/modules/ActiveUtils.js
@@ -1,0 +1,50 @@
+import { matchPattern } from './PatternUtils';
+
+/**
+ * Returns true if a route and params that match the given
+ * pathname are currently active.
+ */
+export function pathnameIsActive(pathname, activePathname, activeRoutes, activeParams) {
+  if (pathname === activePathname || activePathname.indexOf(pathname + '/') === 0)
+    return true;
+
+  var route, pattern;
+  var basename = '';
+  for (var i = 0, len = activeRoutes.length; i < len; ++i) {
+    route = activeRoutes[i];
+    pattern = route.path || '';
+
+    if (pattern.indexOf('/') !== 0)
+      pattern = basename.replace(/\/*$/, '/') + pattern; // Relative paths build on the parent's path.
+
+    var { remainingPathname, paramNames, paramValues } = matchPattern(pattern, pathname);
+
+    if (remainingPathname === '') {
+      return paramNames.every(function (paramName, index) {
+        return String(paramValues[index]) === String(activeParams[paramName]);
+      });
+    }
+
+    basename = pattern;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if all key/value pairs in the given query are
+ * currently active.
+ */
+export function queryIsActive(query, activeQuery) {
+  if (activeQuery == null)
+    return query == null;
+
+  if (query == null)
+    return true;
+
+  for (var p in query)
+    if (query.hasOwnProperty(p) && String(query[p]) !== String(activeQuery[p]))
+      return false;
+
+  return true;
+}

--- a/modules/NavigationMixin.js
+++ b/modules/NavigationMixin.js
@@ -1,103 +1,25 @@
 import invariant from 'invariant';
 import React from 'react';
-import { stringifyQuery } from './QueryUtils';
 
 var { func } = React.PropTypes;
 
-var NavigationMixin = {
+var NavigationMixin = {};
 
-  propTypes: {
-    stringifyQuery: func
-  },
+var RouterNavigationMethods = [
+  'createPath',
+  'createHref',
+  'transitionTo',
+  'replaceWith',
+  'go',
+  'goBack',
+  'goForward'
+];
 
-  getDefaultProps() {
-    return {
-      stringifyQuery
-    };
-  },
-
-  createPath(pathname, query) {
-    var { stringifyQuery } = this.props;
-
-    var queryString;
-    if (query == null || (queryString = stringifyQuery(query)) === '')
-      return pathname;
-
-    return pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString;
-  },
-
-  /**
-   * Returns a string that may safely be used to link to the given
-   * pathname and query.
-   */
-  createHref(pathname, query) {
-    var path = this.createPath(pathname, query);
-    var { history } = this.props;
-
-    if (history && history.createHref)
-      return history.createHref(path);
-
-    return path;
-  },
- 
-  /**
-   * Pushes a new Location onto the history stack.
-   */
-  transitionTo(pathname, query, state=null) {
-    var { history } = this.props;
-
-    invariant(
-      history,
-      'Router#transitionTo needs history'
-    );
-
-    history.pushState(state, this.createPath(pathname, query));
-  },
-
-  /**
-   * Replaces the current Location on the history stack.
-   */
-  replaceWith(pathname, query, state=null) {
-    var { history } = this.props;
-
-    invariant(
-      history,
-      'Router#replaceWith needs history'
-    );
-
-    history.replaceState(state, this.createPath(pathname, query));
-  },
-
-  /**
-   * Navigates forward/backward n entries in the history stack.
-   */
-  go(n) {
-    var { history } = this.props;
-
-    invariant(
-      history,
-      'Router#go needs history'
-    );
-
-    history.go(n);
-  },
-
-  /**
-   * Navigates back one entry in the history stack. This is identical to
-   * the user clicking the browser's back button.
-   */
-  goBack() {
-    this.go(-1);
-  },
-
-  /**
-   * Navigates forward one entry in the history stack. This is identical to
-   * the user clicking the browser's forward button.
-   */
-  goForward() {
-    this.go(1);
-  }
- 
-};
+RouterNavigationMethods.forEach(function (method) {
+  NavigationMixin[method] = function () {
+    var router = this.router;
+    return router[method].apply(router, arguments);
+  };
+});
 
 export default NavigationMixin;

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { createLocation } from 'history';
 import Router from '../Router';
 import Route from '../Route';
+import createRouter from '../createRouter';
 
 describe('Router', function () {
 
@@ -103,5 +104,31 @@ describe('Router', function () {
       done();
     });
   });
+
+  it('renders with a custom `router` prop', function (done) {
+    const router = createRouter({
+      location: createLocation('/hello'),
+      routes: [
+        {
+          childRoutes: [
+            {
+              path: 'hello',
+              component: Child
+            }
+          ],
+          component: Parent
+        }
+      ]
+    });
+
+    React.render((
+      <Router router={router} />
+    ), node, function () {
+      expect(node.textContent.trim()).toMatch(/parent/);
+      expect(node.textContent.trim()).toMatch(/child/);
+      done();
+    });
+  });
+
 
 });

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -73,6 +73,10 @@ class Router {
     let didSyncUpdate = false;
 
     run(this.props.routes, location, (error, state, redirectInfo) => {
+      const nextState = {
+        isTransitioning: false
+      };
+
       if (error) {
         this.props.onError(error)
       } else if (redirectInfo) {
@@ -85,16 +89,11 @@ class Router {
           location.pathname + location.search
         );
       } else {
-        this.setState(state);
+        Object.assign(nextState, state);
       }
 
       didSyncUpdate = true;
-
-      if (this.state.isTransitioning) {
-        this.setState({
-          isTransitioning: false
-        });
-      }
+      this.setState(nextState);
     }, this.state);
 
     if (!didSyncUpdate) {

--- a/modules/createRouter.js
+++ b/modules/createRouter.js
@@ -1,0 +1,233 @@
+import warning from 'warning';
+import invariant from 'invariant';
+import { parseQueryString, stringifyQuery } from './QueryUtils';
+import { pathnameIsActive, queryIsActive } from './ActiveUtils';
+import matchRoutes from './matchRoutes';
+import runTransitionHooks from './runTransitionHooks';
+
+const defaultProps = {
+  isTransitioning: false,
+  location: null,
+  routes: null,
+  params: null,
+  history: null,
+  onError: error => { throw error },
+  stringifyQuery,
+  parseQueryString
+};
+
+export function run(routes, location, callback, prevState = null) {
+  matchRoutes(routes, location, (error, nextState) => {
+    if (error || nextState == null) {
+      callback(error, null);
+    } else {
+      nextState.location = location;
+      runTransitionHooks(prevState, nextState, (error, redirectInfo) => {
+        if (error || redirectInfo) {
+          callback(error, null, redirectInfo);
+        } else {
+          callback(null, nextState);
+        }
+      });
+    }
+  });
+}
+
+class Router {
+  listeners = []
+
+  constructor(props) {
+    this.props = { ...defaultProps, ...props };
+    const { routes, history, location } = this.props;
+
+    if (history) {
+      this.updateHistory(history);
+    } else if (location) {
+      this.updateLocation(location);
+    }
+  }
+
+  setState(state) {
+    this.state = { ...this.state, ...state };
+    this.listeners.forEach(listener => listener());
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  listen(listener) {
+    this.listeners.push(listener);
+
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      this.listeners.splice(index, 1);
+    }
+  }
+
+  updateLocation(location) {
+    if (!location.query) {
+      location.query = this.props.parseQueryString(location.search.substring(1));
+    }
+
+    let didSyncUpdate = false;
+
+    run(this.props.routes, location, (error, state, redirectInfo) => {
+      if (error) {
+        this.props.onError(error)
+      } else if (redirectInfo) {
+        const { pathname, query, state } = redirectInfo;
+        this.replaceWith(pathname, query, state);
+      } else if (state == null) {
+        warning(
+          false,
+          'Location "%s" did not match any routes',
+          location.pathname + location.search
+        );
+      } else {
+        this.setState(state);
+      }
+
+      didSyncUpdate = true;
+
+      if (this.state.isTransitioning) {
+        this.setState({
+          isTransitioning: false
+        });
+      }
+    }, this.state);
+
+    if (!didSyncUpdate) {
+      this.setState({
+        isTransitioning: true
+      });
+    }
+  }
+
+  updateHistory(history) {
+    if (this._unlisten) {
+      this._unlisten();
+      this._unlisten = null;
+    }
+
+    if (history) {
+      this._unlisten = history.listen(this.updateLocation.bind(this));
+    }
+  }
+
+  createPath(pathname, query) {
+    var { stringifyQuery } = this.props;
+
+    var queryString;
+    if (query == null || (queryString = stringifyQuery(query)) === '')
+      return pathname;
+
+    return pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString;
+  }
+
+  /**
+   * Returns a string that may safely be used to link to the given
+   * pathname and query.
+   */
+  createHref(pathname, query) {
+    var path = this.createPath(pathname, query);
+    var { history } = this.props;
+
+    if (history && history.createHref)
+      return history.createHref(path);
+
+    return path;
+  }
+
+  /**
+   * Pushes a new Location onto the history stack.
+   */
+  transitionTo(pathname, query, state=null) {
+    var { history } = this.props;
+
+    invariant(
+      history,
+      'Router#transitionTo needs history'
+    );
+
+    history.pushState(state, this.createPath(pathname, query));
+  }
+
+  /**
+   * Replaces the current Location on the history stack.
+   */
+  replaceWith(pathname, query, state=null) {
+    var { history } = this.props;
+
+    invariant(
+      history,
+      'Router#replaceWith needs history'
+    );
+
+    history.replaceState(state, this.createPath(pathname, query));
+  }
+
+  /**
+   * Navigates forward/backward n entries in the history stack.
+   */
+  go(n) {
+    var { history } = this.props;
+
+    invariant(
+      history,
+      'Router#go needs history'
+    );
+
+    history.go(n);
+  }
+
+  /**
+   * Navigates back one entry in the history stack. This is identical to
+   * the user clicking the browser's back button.
+   */
+  goBack() {
+    this.go(-1);
+  }
+
+  /**
+   * Navigates forward one entry in the history stack. This is identical to
+   * the user clicking the browser's forward button.
+   */
+  goForward() {
+    this.go(1);
+  }
+
+  /**
+   * Returns true if a <Link> to the given pathname/query combination is
+   * currently active.
+   */
+  isActive(pathname, query) {
+    var { location, routes, params } = this.state;
+
+    if (location == null)
+      return false;
+
+    return pathnameIsActive(pathname, location.pathname, routes, params) &&
+      queryIsActive(query, location.query);
+  }
+}
+
+const publicRouterMethods = [
+  'listen',
+  'getState',
+  'createHref',
+  'transitionTo',
+  'replaceWith',
+  'go',
+  'goBack',
+  'goForward',
+  'isActive'
+];
+
+export default function createRouter(props) {
+  const router = new Router(props);
+  return publicRouterMethods.reduce((result, methodName) => {
+    result[methodName] = router[methodName].bind(router);
+    return result;
+  }, {});
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -13,5 +13,6 @@ export State from './State';
 /* utils */
 export { createRoutesFromReactChildren } from './RouteUtils';
 export PropTypes from './PropTypes';
+export createRouter from './createRouter';
 
 export default from './Router';


### PR DESCRIPTION
**Re-submission of #1719 from rackt branch**

This PR refactors the existing Router component class into two separate modules: one for rendering (React component) and one for managing state updates.

## Why?

The new 1.0 API goes a long way toward putting rendering back in hands of users, but `<Router>` still controls the re-render cycle when location changes occur. This is a problem for integrating with external state libraries like Redux.

Additionally, most of what makes React Router cool isn't specific to React. By separating out the React and non-React parts, you could eventually move the core routing stuff into a separate project, and allow people to create bindings for Cycle, Angular... (*cough* Redux *cough*)... whatever. This is similar in spirit to @mjackson's https://github.com/rackt/history or @ryanflorence's https://github.com/ryanflorence/nested-router. (The selfish answer is that I would like this API in order to address https://github.com/acdlite/redux-react-router/issues/1)

## Implementation

I've tried to keep this PR as minimal as possible. None of the original tests have been modified. Existing code has been preserved as much as possible, even in a few cases where it could have been simplified.

`<Router>` keeps the same API as before, with one addition: instead of configuring the router using props, you can create the router using `createRouter(config)` and then pass it to `<Router>` like so:

```js
React.render(<Router history={history} routes={routes} />);

// same as
const router = createRouter({ history, routes });
React.render(<Router router={router} />);
```

Or you can separate it even further by subscribing to the router and passing location directly, like we do with server-side rendering:

```js
router.listen(() => {
  const { location } = router.getState();
  React.render(<Router location={location} routes={routes} />);
});
```

## Looking ahead

If/when this PR is merged, we can take additional steps to simplify the implementation of the base router. For example, right now the router returned by `createRouter()` is an instance of a class, but there's really no reason it needs to be: the only important state is contained inside the history object. Everything else can be implemented as pure functions — the most important function, `Router.run()`, already is. Perhaps in a future PR we can rid of `createRouter()` entirely and replace it with a collection of pure functions, a la nested-router.