### PR TITLE
Add innerComponent ref to return value of Router

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -211,7 +211,7 @@ var Router = createClass({
       'The root route must render a single element'
     );
 
-    return element;
+    return React.cloneElement(element, { ref: 'innerComponent' });
   }
 
 });


### PR DESCRIPTION
Resolves #1743 

This PR adds a ref to the top-level component returned by Router. This is necessary for testing, especially when used with libraries such as [react-test-tree](https://github.com/QubitProducts/react-test-tree).