### PR TITLE
Export createRoutes instead of createRoutesFromReactChildren

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -15,7 +15,7 @@ export State from './State';
 
 /* utils */
 export useRoutes from './useRoutes';
-export { createRoutesFromReactChildren } from './RouteUtils';
+export { createRoutes } from './RouteUtils';
 export PropTypes from './PropTypes';
 
 export default from './Router';


### PR DESCRIPTION
Otherwise third-party tools end up having to re-implement this logic, including `isReactChildren()`.