### PR TITLE
fix import PropTypes got undefined bug

### DIFF
--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -2,19 +2,19 @@ import { PropTypes } from 'react';
 
 var { func, object, arrayOf, oneOfType, element, shape, string } = PropTypes;
 
-function falsy(props, propName, componentName) {
+export function falsy(props, propName, componentName) {
   if (props[propName])
     return new Error(`<${componentName}> should not have a "${propName}" prop`);
 }
 
-var history = shape({
+export var history = shape({
   listen: func.isRequired,
   pushState: func.isRequired,
   replaceState: func.isRequired,
   go: func.isRequired
 });
 
-var location = shape({
+export var location = shape({
   pathname: string.isRequired,
   search: string.isRequired,
   state: object,
@@ -22,10 +22,10 @@ var location = shape({
   key: string
 });
 
-var component = oneOfType([ func, string ]);
-var components = oneOfType([ component, object ]);
-var route = oneOfType([ object, element ]);
-var routes = oneOfType([ route, arrayOf(route) ]);
+export var component = oneOfType([ func, string ]);
+export var components = oneOfType([ component, object ]);
+export var route = oneOfType([ object, element ]);
+export var routes = oneOfType([ route, arrayOf(route) ]);
 
 export default {
   falsy,

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -2,19 +2,19 @@ import { PropTypes } from 'react';
 
 var { func, object, arrayOf, oneOfType, element, shape, string } = PropTypes;
 
-export function falsy(props, propName, componentName) {
+function falsy(props, propName, componentName) {
   if (props[propName])
     return new Error(`<${componentName}> should not have a "${propName}" prop`);
 }
 
-export var history = shape({
+var history = shape({
   listen: func.isRequired,
   pushState: func.isRequired,
   replaceState: func.isRequired,
   go: func.isRequired
 });
 
-export var location = shape({
+var location = shape({
   pathname: string.isRequired,
   search: string.isRequired,
   state: object,
@@ -22,7 +22,17 @@ export var location = shape({
   key: string
 });
 
-export var component = oneOfType([ func, string ]);
-export var components = oneOfType([ component, object ]);
-export var route = oneOfType([ object, element ]);
-export var routes = oneOfType([ route, arrayOf(route) ]);
+var component = oneOfType([ func, string ]);
+var components = oneOfType([ component, object ]);
+var route = oneOfType([ object, element ]);
+var routes = oneOfType([ route, arrayOf(route) ]);
+
+export default {
+  falsy,
+  history,
+  location,
+  component,
+  components,
+  route,
+  router
+};


### PR DESCRIPTION
```
// react-router/modules/index.js
export PropTypes from './PropTypes';
```

This line will get a `undefined` value as `PropTypes`.

We should export whole PropTypes as default or just `export { * as PropTypes } from './PropTypes';`