### PR TITLE
[fixed] #1148 regex for detecting trailing slashes

### DIFF
--- a/modules/PathUtils.js
+++ b/modules/PathUtils.js
@@ -4,7 +4,7 @@ var qs = require('qs');
 
 var paramCompileMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|[*.()\[\]\\+|{}^$]/g;
 var paramInjectMatcher = /:([a-zA-Z_$][a-zA-Z0-9_$?]*[?]?)|[*]/g;
-var paramInjectTrailingSlashMatcher = /\/\/\?|\/\?\/|\/\?/g;
+var paramInjectTrailingSlashMatcher = /\/\/\?|\/\?\/|\/\?(?![^\/=]+=.*$)/g;
 var queryMatcher = /\?(.*)$/;
 
 var _compiledPatterns = {};

--- a/modules/__tests__/PathUtils-test.js
+++ b/modules/__tests__/PathUtils-test.js
@@ -187,6 +187,14 @@ describe('PathUtils.injectParams', function () {
     });
   });
 
+  describe('when a path has query params', function() {
+    var pattern = '/a/:b/?c/?d=e';
+
+    it('should not change the query params', function() {
+        expect(PathUtils.injectParams(pattern, {b: '123'})).toEqual('/a/123/c/?d=e');
+    });
+  });
+
   describe('when a pattern has dynamic segments', function () {
     var pattern = 'comments/:id/edit';
 


### PR DESCRIPTION
Fixes the regex for trailing slashes in PathUtils to not match /? if it
is at the beginning of a url's query params