### PR TITLE
Add failing tests for optional param groups

### DIFF
--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -45,6 +45,22 @@ describe('formatPattern', function () {
       });
     });
 
+    describe('and a param group is optional', function () {
+      var pattern = '/comments(/edit/:id)(/mode/:modeType)';
+
+      it('returns the correct path when all params are supplied', function () {
+        expect(formatPattern(pattern, {id:'123', modeType: 'foo' })).toEqual('/comments/edit/123/mode/foo');
+      });
+
+      it('returns the correct path when param is not supplied', function () {
+        expect(formatPattern(pattern, {})).toEqual('/comments');
+      });
+
+      it('returns the correct path when one param is not supplied', function () {
+        expect(formatPattern(pattern, { modeType: 'foo' })).toEqual('/comments/mode/foo');
+      });
+    });
+
     describe('and all params are present', function () {
       it('returns the correct path', function () {
         expect(formatPattern(pattern, { id: 'abc' })).toEqual('/comments/abc/edit');


### PR DESCRIPTION
Hey! I wanted to check and see what y'all think of potentially modifying `formatPattern` to support optional param groups a little better. I've got an odd case in an application where we're using optional groups of parameters instead of query params, effectively.

I'm using `formatPattern` to generate paths for `transitionTo` in a couple of places, and it's not returning the URLs that I would expect. The behavior I hoped for is that if there's an optional group of parameters, like `/foo(/type/:typeName)`, that if no `typeName` value was present, the path generated by `formatPattern` wouldn't include that optional segment.

- Expected result: `/foo`
- Actual result: `/foo/type/`

If this isn't something `formatPattern` should handle, I expect that the right solution is for me to use splats and handle it manually.

See the attached failing tests for examples.