### PR TITLE
Add failing tests for route matching with hash

### DIFF
--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -100,6 +100,27 @@ describe('matchRoutes', function () {
       });
     });
 
+    describe('when the location matches a route with hash', function () {
+      it('matches the correct routes', function (done) {
+        matchRoutes(routes, createLocation('/users#about'), function (error, match) {
+          assert(match);
+          expect(match.routes).toEqual([ RootRoute, UsersRoute, UsersIndexRoute ]);
+          done();
+        });
+      });
+    });
+
+    describe('when the location matches a deeply nested route with params and hash', function () {
+      it('matches the correct routes and params', function (done) {
+        matchRoutes(routes, createLocation('/users/5/abc#about'), function (error, match) {
+          assert(match);
+          expect(match.routes).toEqual([ RootRoute, UsersRoute, UserRoute, PostRoute ]);
+          expect(match.params).toEqual({ userID: '5', postID: 'abc' });
+          done();
+        });
+      });
+    });
+
     describe('when the location matches an absolute route', function () {
       it('matches the correct routes', function (done) {
         matchRoutes(routes, createLocation('/about'), function (error, match) {


### PR DESCRIPTION
Hash links don't seem to work, as far as I can tell. The router attempts to navigate to a route that includes the hash at the end of it, resulting in a route not found error. Attached are a couple of failing tests for the issue.

Related issue: #394 