### PR TITLE
added a test for nested routes

### DIFF
--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -158,6 +158,27 @@ describe('Router', function () {
       });
     });
 
+    it('does not double escape when nested', function(done) {
+      // https://github.com/rackt/react-router/issues/1574
+      let MyWrapperComponent = React.createClass({
+        render () { return this.props.children; }
+      });
+      let MyComponent = React.createClass({
+        render () { return <div>{this.props.params.some_token}</div> }
+      });
+
+      React.render((
+        <Router history={createHistory('/point/aaa%2Bbbb')}>
+          <Route component={MyWrapperComponent}>
+            <Route path="point/:some_token" component={MyComponent} />
+          </Route>
+        </Router>
+      ), node, function () {
+        expect(node.textContent.trim()).toEqual('aaa+bbb');
+        done();
+      });
+    });
+
     it('is happy to have colons in parameter values', function(done) {
       // https://github.com/rackt/react-router/issues/1759
       let MyComponent = React.createClass({


### PR DESCRIPTION
This is following #1574. The test you added was passing in beta3 so I added a test case which fails. Note that it's now passing against master (which is nice)! It's just to make sure we cover all cases.

This is against beta3

![image](https://cloud.githubusercontent.com/assets/4422516/9798367/7c947f4e-57ce-11e5-919e-0dba29c0faa4.png)


And this is against current master

![screen shot 2015-09-10 at 3 05 39 pm](https://cloud.githubusercontent.com/assets/4422516/9798197/717e41d6-57cd-11e5-9dfa-950dc31027f1.png)


---

If you want to test against beta3 the code needs to be adapted a bit

```jsx
describe('at a route with special characters', function () {
  it('does not double escape', function(done) {
    // https://github.com/rackt/react-router/issues/1574
    let MyComponent = React.createClass({
      render () { return <div>{this.props.params.some_token}</div> }
    })

    React.render((
      <Router history={new MemoryHistory('/point/aaa%2Bbbb')}>
        <Route path="point/:some_token" component={MyComponent} />
      </Router>
    ), div, function () {
      expect(div.textContent.trim()).toEqual('aaa+bbb');
      done();
    });
  });

  it('does not double escape when nested', function(done) {
    // https://github.com/rackt/react-router/issues/1574
    let MyWrapperComponent = React.createClass({
      render () { return this.props.children; }
    });
    let MyComponent = React.createClass({
      render () { return <div>{this.props.params.some_token}</div> }
    });

    React.render((
      <Router history={new MemoryHistory('/point/aaa%2Bbbb')}>
        <Route component={MyWrapperComponent}>
          <Route path="point/:some_token" component={MyComponent} />
        </Route>
      </Router>
    ), div, function () {
      expect(div.textContent.trim()).toEqual('aaa+bbb');
      done();
    });
  });
});  
```