### PR TITLE
Changed to ReactDOM, and added Navigation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ var User = React.createClass({
 // Declarative route configuration (could also load this config lazily
 // instead, all you really need is a single root route, you don't need to
 // colocate the entire config).
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <Route path="about" component={About}/>

--- a/docs/Histories.md
+++ b/docs/Histories.md
@@ -57,6 +57,14 @@ React Router. It uses the [History](https://developer.mozilla.org/en-US/docs/Web
 API built into the browser to manipulate the url, creating real urls that
 look like `example.com/some/path`.
 
+To use, set the `history` prop on your `Router`:
+
+```js
+<Router history={createBrowserHistory()}>
+  ... 
+</Router>
+```
+
 ### Configuring Your Server
 
 Your server must be ready to handle real urls. When the app first loads

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -45,7 +45,7 @@ var App = React.createClass({
   }
 });
 
-React.render(<App />, document.body);
+ReactDOM.render(<App />, document.body);
 ```
 
 As the hash portion of the URL changes, `<App>` will render a different `<Child>` by branching on `this.state.route`. Pretty straightforward stuff. But it gets complicated fast.
@@ -125,7 +125,7 @@ var App = React.createClass({
 
 // Finally, we render a <Router> with some <Route>s.
 // It does all the fancy routing stuff for us.
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <Route path="about" component={About} />
@@ -147,7 +147,7 @@ var routes = {
   ]
 };
 
-React.render(<Router routes={routes} />, document.body);
+ReactDOM.render(<Router routes={routes} />, document.body);
 ```
 
 ## Adding More UI
@@ -174,7 +174,7 @@ var Inbox = React.createClass({
   }
 });
 
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <Route path="about" component={About} />

--- a/docs/Navigation.md
+++ b/docs/Navigation.md
@@ -3,6 +3,25 @@
 Mixes in the navigation methods of the router for convenient routing
 from within components.
 
+## Usage
+
+```js
+var ReactRouter = require('react-router')
+
+var myComponent = React.createComponent({
+	mixins : [ReactRouter.Navigation],
+	goToStore : function() {
+		// store is the route name, and storeId is hamilton
+		// will change to /store/hamilton
+		var city = 'hamilton';
+		this.transitionTo('/store/' + city);
+	},
+	render : function() {
+		return (<button onClick={this.goToStore}>Change Pages</button>)
+	}
+});
+```
+
 ## Methods
 
 ### `transitionTo(pathname, query, state)`

--- a/docs/Route Component.md
+++ b/docs/Route Component.md
@@ -29,7 +29,7 @@ The matched child route elements to be rendered.
 ### Example
 
 ```js
-React.render((
+ReactDOM.render((
   <Router history={history}>
     <Route path="/" component={App}>
       <Route path="groups" components={Groups} />
@@ -57,7 +57,7 @@ When a route has multiple components, the child elements are available by name o
 ### Example
 
 ```js
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <Route path="groups" components={{main: Groups, sidebar: GroupsSidebar}} />

--- a/docs/RouteConfiguration.md
+++ b/docs/RouteConfiguration.md
@@ -44,7 +44,7 @@ var Message = React.createClass({
   }
 });
 
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <Route path="about" component={About} />
@@ -78,7 +78,7 @@ var Dashboard = React.createClass({
   }
 });
 
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       {/* Show the dashboard at / */}
@@ -108,7 +108,7 @@ URL                     | Components
 It would be nice if we could remove the `/inbox` segment from the `/inbox/messages/:id` URL pattern, but still render `Message` nested inside the `App -> Inbox` UI. Absolute `path`s let us do exactly that.
 
 ```js
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <IndexRoute component={Dashboard} />
@@ -144,7 +144,7 @@ Not to worry. We can use a `<Redirect>` to make sure that URL still works!
 ```js
 import { Redirect } from 'react-router';
 
-React.render((
+ReactDOM.render((
   <Router>
     <Route path="/" component={App}>
       <IndexRoute component={Dashboard} />
@@ -202,5 +202,5 @@ var routeConfig = [
   }
 ];
 
-React.render(<Router routes={routeConfig} />, document.body);
+ReactDOM.render(<Router routes={routeConfig} />, document.body);
 ```


### PR DESCRIPTION
A few changes to the docs:

* Changed to using `ReactDOM.render()` as in 0.14 that is changing
* Added a transitionTo  / mixin example
* Added a History example - I wasn't able to find any docs on this but fished it out of an issue. 