### PR TITLE
Allow async route getters return a reactElement

### DIFF
--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -1,6 +1,10 @@
+import React from 'react';
+import Route from '../Route';
+
 import assert from 'assert';
 import expect from 'expect';
 import { createLocation } from 'history';
+import { createRoutes } from '../RouteUtils';
 import matchRoutes from '../matchRoutes';
 
 describe('matchRoutes', function () {
@@ -180,5 +184,45 @@ describe('matchRoutes', function () {
     });
 
     describeRoutes();
+  });
+
+  describe('an asynchronous JSX route config', function () {
+    var jsxRoutes;
+
+    beforeEach(function () {
+      var getChildRoutes = function (location, callback) {
+          setTimeout(function () {
+            callback(null, <Route path=":userID" />);
+          });
+      };
+      var getIndexRoute = function (location, callback) {
+        setTimeout(function () {
+          callback(null, <Route name='jsx' />);
+        });
+      };
+      jsxRoutes = createRoutes([
+        <Route name="users"
+               path="users"
+               getChildRoutes={getChildRoutes}
+               getIndexRoute={getIndexRoute} />
+      ]);
+    });
+
+    it('when getChildRoutes callback returns reactElements', function(done) {
+      matchRoutes(jsxRoutes, createLocation('/users/5'), function (error, match) {
+         assert(match);
+         expect(match.routes.map(r => r.path)).toEqual([ 'users', ':userID' ]);
+         expect(match.params).toEqual({ userID: '5' });
+         done();
+      });
+    });
+
+    it('when getIndexRoute callback returns reactElements', function(done) {
+      matchRoutes(jsxRoutes, createLocation('/users'), function (error, match) {
+         assert(match);
+         expect(match.routes.map(r => r.name)).toEqual([ 'users', 'jsx' ]);
+         done();
+      });
+    });
   });
 });

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -1,11 +1,14 @@
 import { loopAsync } from './AsyncUtils';
 import { matchPattern } from './PatternUtils';
+import { createRoutes } from './RouteUtils';
 
 function getChildRoutes(route, location, callback) {
   if (route.childRoutes) {
     callback(null, route.childRoutes);
   } else if (route.getChildRoutes) {
-    route.getChildRoutes(location, callback);
+    route.getChildRoutes(location, function(error, childRoutes) {
+        callback(error, !error && createRoutes(childRoutes));
+    });
   } else {
     callback();
   }
@@ -15,7 +18,9 @@ function getIndexRoute(route, location, callback) {
   if (route.indexRoute) {
     callback(null, route.indexRoute);
   } else if (route.getIndexRoute) {
-    route.getIndexRoute(location, callback);
+    route.getIndexRoute(location, function(error, indexRoute) {
+        callback(error, !error && createRoutes(indexRoute)[0]);
+    });
   } else {
     callback();
   }


### PR DESCRIPTION
Example

```
<Route getChildRoutes={function(cb) {
    cb(null, [<Route path="loaded"/>]);
}} />
```
