### PR TITLE
Docs update on getComponents

### DIFF
--- a/docs/advanced/DynamicRouting.md
+++ b/docs/advanced/DynamicRouting.md
@@ -28,7 +28,7 @@ var CourseRoute = {
     })
   },
 
-  getComponents(callback) {
+  getComponents(location, callback) {
     require.ensure([], function (require) {
       callback(null, require('./components/Course'))
     })

--- a/docs/api/Route.md
+++ b/docs/api/Route.md
@@ -95,7 +95,7 @@ var Users = React.createClass({
 });
 ```
 
-#### `getComponent(callback)`
+#### `getComponent(location, callback)`
 
 Same as `component` but asynchronous, useful for
 code-splitting.
@@ -107,13 +107,13 @@ code-splitting.
 ##### Example
 
 ```js
-<Route path="courses/:courseId" getComponent={(cb) => {
+<Route path="courses/:courseId" getComponent={(location, cb) => {
   // do asynchronous stuff to find the components
   cb(null, Course);
 }}/>
 ```
 
-#### `getComponents(callback)`
+#### `getComponents(location, callback)`
 
 Same as `components` but asynchronous, useful for
 code-splitting.
@@ -125,7 +125,7 @@ code-splitting.
 ##### Example
 
 ```js
-<Route path="courses/:courseId" getComponent={(cb) => {
+<Route path="courses/:courseId" getComponent={(location, cb) => {
   // do asynchronous stuff to find the components
   cb(null, {sidebar: CourseSidebar, content: Course});
 }}/>


### PR DESCRIPTION
Docs didn't match the recent api changes to the getComponents and getComponent functions from beta4 to rc1

```javascript

// changed from

getComponents(callback)

// to

getComponents(location, callback)

```