### PR TITLE
Fix error in auth-flow example

### DIFF
--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -113,9 +113,10 @@ var Logout = React.createClass({
   }
 });
 
-function requireAuth(nextState, redirectTo) {
-  if (!auth.loggedIn())
-    redirectTo('/login', null, { nextPathname: nextState.location.pathname });
+function requireAuth(nextState, replaceState) {
+  if (!auth.loggedIn()) {
+    replaceState(null, '/login');
+  }
 }
 
 React.render((

--- a/examples/auth-flow/app.js
+++ b/examples/auth-flow/app.js
@@ -115,7 +115,7 @@ var Logout = React.createClass({
 
 function requireAuth(nextState, replaceState) {
   if (!auth.loggedIn()) {
-    replaceState(null, '/login');
+    replaceState({ nextPathname: nextState.location.pathname }, '/login');
   }
 }
 


### PR DESCRIPTION
Fix usage of onEnter function from the auth-flow example.

Was giving this error:
```
Uncaught TypeError: Cannot read property 'indexOf' of null
```