### PR TITLE
Add failing test case for query params on server

### DIFF
--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -86,7 +86,7 @@ describe('server rendering', function () {
     })
   })
 
-  it.only('works with query params', function (done) {
+  it('works with query params', function (done) {
     const location = createLocation('/dashboard?message=Hello')
     match({ routes, location }, function (error, redirectLocation, renderProps) {
       const string = React.renderToString(

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -1,4 +1,4 @@
-/*eslint-env mocha */
+``/*eslint-env mocha */
 /*eslint react/prop-types: 0*/
 import expect from 'expect'
 import React from 'react'
@@ -13,12 +13,17 @@ describe('server rendering', function () {
   beforeEach(function () {
     App = React.createClass({
       render() {
+        let message = this.props.location.query && this.props.location.query.message
+          ? <p>{this.props.query.location.query.message}</p>
+          : null;
+
         return (
           <div className="App">
             <h1>App</h1>
             <Link to="/about" activeClassName="about-is-active">About</Link>{' '}
             <Link to="/dashboard" activeClassName="dashboard-is-active">Dashboard</Link>
             <div>
+              {message}
               {this.props.children}
             </div>
           </div>
@@ -80,6 +85,17 @@ describe('server rendering', function () {
       done()
     })
   })
+
+  it.only('works with query params', function (done) {
+    const location = createLocation('/dashboard?message=Hello')
+    match({ routes, location }, function (error, redirectLocation, renderProps) {
+      const string = React.renderToString(
+        <RoutingContext {...renderProps} />
+      )
+      expect(string).toMatch(/Hello/)
+      done()
+    })
+  });
 
   it('renders active Links as active', function (done) {
     const location = createLocation('/about')


### PR DESCRIPTION
Query params are not available when doing server-side rendering with `match()`. This is because queries are only added to location objects by `useQueries()`, when it passes `location` to a listener: https://github.com/rackt/history/blob/master/modules/useQueries.js#L28-L29

Queries work on the client because match is called from inside a listener: https://github.com/rackt/react-router/blob/master/modules/useRoutes.js#L210

But they don't work on the server, because the `match.js` module calls `history.match()` directly without listening: https://github.com/rackt/react-router/blob/master/modules/match.js#L20

This PR adds a failing test case. I would have tried to fix it as well, but the solution doesn't seem all that straightforward. You could listen to the history object and then immediately unlisten to get the proper location object, but that seems a bit hacky.