### PR TITLE
Create table of contents for 0.13.x docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ React Router
 
 A complete routing library for React.
 
-**Note: We are currently working hard on some major API changes for version 1.0. You can [follow our progress, here](https://github.com/rackt/react-router/tree/master)!**
-
-[Docs](https://rackt.github.io/react-router/)
+[Docs](/doc)
 
 Important Notes
 ---------------

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,33 @@
+## Table of Contents
+
+* [Read Me](/README.md)
+* Router
+  * [Overview](/doc/00 Guides/Router Overview.md)
+  * [Router.create](/doc/02 Top-Level/Router.create.md)
+  * [Router.run](/doc/02 Top-Level/Router.run.md)
+* Route Components
+  * [Route](/doc/01 Route Configuration/Route.md)
+  * [DefaultRoute](/doc/01 Route Configuration/DefaultRoute.md)
+  * [NotFoundRoute](/doc/01 Route Configuration/NotFoundRoute.md)
+  * [Redirect](/doc/01 Route Configuration/Redirect.md)
+* Handler Components
+  * [Overview](/doc/03 Components/Route Handler.md)
+  * [Transition](/doc/07 Misc/Transition.md)
+* Other Components
+  * [Root](/doc/03 Components/Link.md)
+  * [Link](/doc/03 Components/Link.md)
+  * [RouteHandler](/doc/03 Components/RouteHandler.md)
+* Locations
+  * [HashLocation](/doc/04 Locations/HashLocation.md)
+  * [HistoryLocation](/doc/04 Locations/HistoryLocation.md)
+  * [RefreshLocation](/doc/04 Locations/RefreshLocation.md)
+  * [StaticLocation](/doc/04 Locations/StaticLocation.md)
+  * [TestLocation](/doc/04 Locations/TestLocation.md)
+  * [Custom](/doc/04 Locations/Custom Location.md)
+* Scroll Behaviors
+  * [ImitateBrowserBehavior](/doc/05 Scroll Behaviors/ImitateBrowserBehavior.md)
+  * [ScrollToTopBehavior](/doc/05 Scroll Behaviors/ScrollToTopBehavior.md)
+* Mixins
+  * [Navigation](/doc/06 Mixins/Navigation.md)
+  * [State](/doc/06 Mixins/State.md)
+* [Upgrade Guide](https://github.com/rackt/react-router/blob/master/UPGRADE_GUIDE.md)


### PR DESCRIPTION
- Removes the link to the old github.io site (currently redirected to the repo's master/1.0.x docs)
- Adds a link to the 0.13.x branch's docs
- Adds a README w/ a table of contents for the 0.13.x docs