### PR TITLE
Update activeClassName docs

### DIFF
--- a/docs/api/Link.md
+++ b/docs/api/Link.md
@@ -22,7 +22,7 @@ State to persist to the `location`.
 
 #### `activeClassName`
 
-The className a `Link` receives when its route is active. Defaults to `active`.
+The className a `Link` receives when its route is active. No active class by default.
 
 #### `activeStyle`
 


### PR DESCRIPTION
Updates Link's activeClassName docs to reflect v1.0 behavior: activeClassName is now opt-in and no longer defaults to "active".