### PR TITLE
[fixed] Update state to nextState after running RouteHook

### DIFF
--- a/modules/useRoutes.js
+++ b/modules/useRoutes.js
@@ -47,11 +47,7 @@ function useRoutes(createHistory) {
           if (error) {
             callback(error, null, null)
           } else if (nextState) {
-            finishMatch({ ...nextState, location }, function (err, nextLocation, nextState) {
-              if (nextState)
-                state = nextState
-              callback(err, nextLocation, nextState)
-            })
+            finishMatch({ ...nextState, location }, callback)
           } else {
             callback(null, null, null)
           }
@@ -81,7 +77,9 @@ function useRoutes(createHistory) {
             if (error) {
               callback(error)
             } else {
-              callback(null, null, { ...nextState, components })
+              nextState = { ...nextState, components };
+              state = nextState;
+              callback(null, null, nextState);
             }
           })
         }

--- a/modules/useRoutes.js
+++ b/modules/useRoutes.js
@@ -77,9 +77,9 @@ function useRoutes(createHistory) {
             if (error) {
               callback(error)
             } else {
-              nextState = { ...nextState, components };
-              state = nextState;
-              callback(null, null, nextState);
+              nextState = { ...nextState, components }
+              state = nextState
+              callback(null, null, nextState)
             }
           })
         }


### PR DESCRIPTION
If any route hooks are registered, [transitionHook calls matchRoutes](https://github.com/rackt/react-router/blob/v1.0.0-rc1/modules/useRoutes.js#L106) to determine what route hooks and caches the computed next state as partialNextState.  However when these cached results are used later [in the history.listen callback](https://github.com/rackt/react-router/blob/v1.0.0-rc1/modules/useRoutes.js#L44), it shortcuts logic in the main path [to update the history object's state](https://github.com/rackt/react-router/blob/v1.0.0-rc1/modules/useRoutes.js#L52).  

Since this is required of all paths that call finishMatch (including the one that uses the cached partialNextState), it's been moved there.