### PR TITLE
add qs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "history": "^1.9.0",
     "invariant": "^2.0.0",
+    "qs": "^5.1.0",
     "warning": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
QueryUtils depends on qs, but it's not in package.json

line 9 
```
var _qs = require('qs');
```