### PR TITLE
Remove dead "Recipes" link from docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,6 @@
   * [Server Rendering](/docs/advanced/ServerRendering.md)
   * [Component Lifecycle](/docs/advanced/ComponentLifecycle.md)
   * [Navigating Outside of Components](/docs/advanced/NavigatingOutsideOfComponents.md)
-* [Recipes](/docs/recipes/README.md)
 * [Upgrade Guide](/UPGRADE_GUIDE.md)
 * [Troubleshooting](/docs/Troubleshooting.md)
 * [Glossary](/docs/Glossary.md)


### PR DESCRIPTION
The Recipes page was removed by @mjackson in 59aadc29f, but it was still
linked to from the readme.