### PR TITLE
Remove unused QueryUtils

### DIFF
--- a/modules/QueryUtils.js
+++ b/modules/QueryUtils.js
@@ -1,9 +1,0 @@
-import qs from 'qs'
-
-export function stringifyQuery(query) {
-  return qs.stringify(query, { arrayFormat: 'brackets' })
-}
-
-export function parseQueryString(queryString) {
-  return qs.parse(queryString)
-}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "history": "^1.9.0",
     "invariant": "^2.0.0",
-    "qs": "^5.1.0",
     "warning": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The QueryUtils module is the only one with a dependency on the `qs` module (as raised in #1985), but it isn't in use anywhere in the library. We can remove both it and its `qs` dependency.