### PR TITLE
[added] Support <Redirect to="relative/path">

### DIFF
--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -23,15 +23,22 @@ const Redirect = React.createClass({
       if (route.from)
         route.path = route.from
 
-      // TODO: Handle relative pathnames, see #1658
-      invariant(
-        route.to.charAt(0) === '/',
-        '<Redirect to> must be an absolute path. This should be fixed in the future'
-      )
-
       route.onEnter = function (nextState, replaceState) {
         const { location, params } = nextState
-        const pathname = route.to ? formatPattern(route.to, params) : location.pathname
+
+        let pathname
+        if (route.to.charAt(0) === '/') {
+          pathname = formatPattern(route.to, params)
+        }
+        else if (!route.to) {
+          pathname = location.pathname
+        }
+        else {
+          let routeIndex = nextState.routes.indexOf(route)
+          let parentPattern = Redirect.getRoutePattern(nextState.routes, routeIndex - 1)
+          let pattern = parentPattern.replace(/\/*$/, '/') + route.to
+          pathname = formatPattern(pattern, params)
+        }
 
         replaceState(
           route.state || location.state,
@@ -41,6 +48,22 @@ const Redirect = React.createClass({
       }
 
       return route
+    },
+
+    getRoutePattern(routes, routeIndex) {
+      let parentPattern = ''
+
+      for (let i = routeIndex; i >= 0; i--) {
+        let route = routes[i]
+        let pattern = route.path || ''
+        parentPattern = pattern.replace(/\/*$/, '/') + parentPattern
+
+        if (pattern.indexOf('/') === 0) {
+          break
+        }
+      }
+
+      return '/' + parentPattern
     }
 
   },

--- a/modules/__tests__/Redirect-test.js
+++ b/modules/__tests__/Redirect-test.js
@@ -29,4 +29,32 @@ describe('A <Redirect>', function () {
     })
   })
 
+  it('works with relative paths', function (done) {
+    React.render((
+      <Router history={createHistory('/nested/route1')}>
+        <Route path="nested">
+          <Route path="route2" />
+          <Redirect from="route1" to="route2" />
+        </Route>
+      </Router>
+    ), node, function () {
+      expect(this.state.location.pathname).toEqual('/nested/route2')
+      done()
+    })
+  })
+
+  it('works with relative paths with param', function (done) {
+    React.render((
+      <Router history={createHistory('/nested/1/route1')}>
+        <Route path="nested/:id">
+          <Route path="route2" />
+          <Redirect from="route1" to="route2" />
+        </Route>
+      </Router>
+    ), node, function () {
+      expect(this.state.location.pathname).toEqual('/nested/1/route2')
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
This is a rough implementation that can be cleaned up further, but I wanted to request for comments on the approach first before cleaning the implementation.

It adds `patterns` to `nextState`/`match` (State) in order to find the parent's matched pattern before appending to it. It can instead traverse parent routes and prepend the paths until it finds the first route that contains `/`. That adds more logic to Redirect but I'm happy to do that as well.

Resolves #1905