### PR TITLE
Dependency inject React.

### DIFF
--- a/modules/History.js
+++ b/modules/History.js
@@ -1,13 +1,18 @@
-import { history } from './PropTypes'
+import createPropTypes from './PropTypes'
 
-const History = {
+export default function createHistory(React) {
+  const { history } = createPropTypes(React)
 
-  contextTypes: { history },
+  const History = {
 
-  componentWillMount () {
-    this.history = this.context.history
+    contextTypes: { history },
+
+    componentWillMount () {
+      this.history = this.context.history
+    }
+
   }
 
-}
+  return History
 
-export default History
+}

--- a/modules/IndexLink.js
+++ b/modules/IndexLink.js
@@ -1,12 +1,15 @@
-import React from 'react'
-import Link from './Link'
+import createLink from './Link'
 
-const IndexLink = React.createClass({
+export default function createIndexLink(React) {
+  const Link = createLink(React)
 
-  render() {
-    return <Link {...this.props} onlyActiveOnIndex={true} />
-  }
+  const IndexLink = React.createClass({
 
-})
+    render() {
+      return <Link {...this.props} onlyActiveOnIndex={true} />
+    }
 
-export default IndexLink
+  })
+
+  return IndexLink
+}

--- a/modules/IndexRoute.js
+++ b/modules/IndexRoute.js
@@ -1,47 +1,52 @@
-import React from 'react'
 import invariant from 'invariant'
 import warning from 'warning'
-import { createRouteFromReactElement } from './RouteUtils'
-import { component, components, falsy } from './PropTypes'
+import createRouteUtils from './RouteUtils'
+import createPropTypes from './PropTypes'
 
-const { bool, func } = React.PropTypes
+export default function createIndexRoute(React) {
+  const { createRouteFromReactElement } = createRouteUtils(React)
+  const { component, components, falsy } = createPropTypes(React)
 
-/**
- * An <IndexRoute> is used to specify its parent's <Route indexRoute> in
- * a JSX route config.
- */
-const IndexRoute = React.createClass({
+  const { bool, func } = React.PropTypes
 
-  statics: {
+  /**
+   * An <IndexRoute> is used to specify its parent's <Route indexRoute> in
+   * a JSX route config.
+   */
+  const IndexRoute = React.createClass({
 
-    createRouteFromReactElement(element, parentRoute) {
-      if (parentRoute) {
-        parentRoute.indexRoute = createRouteFromReactElement(element)
-      } else {
-        warning(
-          false,
-          'An <IndexRoute> does not make sense at the root of your route config'
-        )
+    statics: {
+
+      createRouteFromReactElement(element, parentRoute) {
+        if (parentRoute) {
+          parentRoute.indexRoute = createRouteFromReactElement(element)
+        } else {
+          warning(
+            false,
+            'An <IndexRoute> does not make sense at the root of your route config'
+          )
+        }
       }
+
+    },
+
+    propTypes: {
+      path: falsy,
+      ignoreScrollBehavior: bool,
+      component,
+      components,
+      getComponents: func
+    },
+
+    render() {
+      invariant(
+        false,
+        '<IndexRoute> elements are for router configuration only and should not be rendered'
+      )
     }
 
-  },
+  })
 
-  propTypes: {
-    path: falsy,
-    ignoreScrollBehavior: bool,
-    component,
-    components,
-    getComponents: func
-  },
+  return IndexRoute
 
-  render() {
-    invariant(
-      false,
-      '<IndexRoute> elements are for router configuration only and should not be rendered'
-    )
-  }
-
-})
-
-export default IndexRoute
+}

--- a/modules/Lifecycle.js
+++ b/modules/Lifecycle.js
@@ -1,69 +1,72 @@
-import React from 'react'
 import invariant from 'invariant'
 
-const { object } = React.PropTypes
+export default function createLifecycle(React) {
 
-/**
- * The Lifecycle mixin adds the routerWillLeave lifecycle method
- * to a component that may be used to cancel a transition or prompt
- * the user for confirmation.
- *
- * On standard transitions, routerWillLeave receives a single argument: the
- * location we're transitioning to. To cancel the transition, return false.
- * To prompt the user for confirmation, return a prompt message (string).
- *
- * routerWillLeave does not receive a location object during the beforeunload
- * event in web browsers (assuming you're using the useBeforeUnload history
- * enhancer). In this case, it is not possible for us to know the location
- * we're transitioning to so routerWillLeave must return a prompt message to
- * prevent the user from closing the tab.
- */
-const Lifecycle = {
+  const { object } = React.PropTypes
 
-  propTypes: {
-    // Route components receive the route object as a prop.
-    route: object
-  },
+  /**
+   * The Lifecycle mixin adds the routerWillLeave lifecycle method
+   * to a component that may be used to cancel a transition or prompt
+   * the user for confirmation.
+   *
+   * On standard transitions, routerWillLeave receives a single argument: the
+   * location we're transitioning to. To cancel the transition, return false.
+   * To prompt the user for confirmation, return a prompt message (string).
+   *
+   * routerWillLeave does not receive a location object during the beforeunload
+   * event in web browsers (assuming you're using the useBeforeUnload history
+   * enhancer). In this case, it is not possible for us to know the location
+   * we're transitioning to so routerWillLeave must return a prompt message to
+   * prevent the user from closing the tab.
+   */
+  const Lifecycle = {
 
-  contextTypes: {
-    history: object.isRequired,
-    // Nested children receive the route as context, either
-    // set by the route component using the RouteContext mixin
-    // or by some other ancestor.
-    route: object
-  },
+    propTypes: {
+      // Route components receive the route object as a prop.
+      route: object
+    },
 
-  _getRoute() {
-    const route = this.props.route || this.context.route
+    contextTypes: {
+      history: object.isRequired,
+      // Nested children receive the route as context, either
+      // set by the route component using the RouteContext mixin
+      // or by some other ancestor.
+      route: object
+    },
 
-    invariant(
-      route,
-      'The Lifecycle mixin needs to be used either on 1) a <Route component> or ' +
-      '2) a descendant of a <Route component> that uses the RouteContext mixin'
-    )
+    _getRoute() {
+      const route = this.props.route || this.context.route
 
-    return route
-  },
+      invariant(
+        route,
+        'The Lifecycle mixin needs to be used either on 1) a <Route component> or ' +
+        '2) a descendant of a <Route component> that uses the RouteContext mixin'
+      )
 
-  componentWillMount() {
-    invariant(
-      this.routerWillLeave,
-      'The Lifecycle mixin requires you to define a routerWillLeave method'
-    )
+      return route
+    },
 
-    this.context.history.registerRouteHook(
-      this._getRoute(),
-      this.routerWillLeave
-    )
-  },
+    componentWillMount() {
+      invariant(
+        this.routerWillLeave,
+        'The Lifecycle mixin requires you to define a routerWillLeave method'
+      )
 
-  componentWillUnmount() {
-    this.context.history.unregisterRouteHook(
-      this._getRoute(),
-      this.routerWillLeave
-    )
+      this.context.history.registerRouteHook(
+        this._getRoute(),
+        this.routerWillLeave
+      )
+    },
+
+    componentWillUnmount() {
+      this.context.history.unregisterRouteHook(
+        this._getRoute(),
+        this.routerWillLeave
+      )
+    }
+
   }
 
-}
+  return Lifecycle
 
-export default Lifecycle
+}

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -1,7 +1,4 @@
-import React from 'react'
 import warning from 'warning'
-
-const { bool, object, string, func } = React.PropTypes
 
 function isLeftClickEvent(event) {
   return event.button === 0
@@ -19,100 +16,104 @@ function isEmptyObject(object) {
   return true
 }
 
-/**
- * A <Link> is used to create an <a> element that links to a route.
- * When that route is active, the link gets an "active" class name
- * (or the value of its `activeClassName` prop).
- *
- * For example, assuming you have the following route:
- *
- *   <Route path="/posts/:postID" component={Post} />
- *
- * You could use the following component to link to that route:
- *
- *   <Link to={`/posts/${post.id}`} />
- *
- * Links may pass along location state and/or query string parameters
- * in the state/query props, respectively.
- *
- *   <Link ... query={{ show: true }} state={{ the: 'state' }} />
- */
-const Link = React.createClass({
+export default function createLink(React) {
+  const { bool, object, string, func } = React.PropTypes
 
-  contextTypes: {
-    history: object
-  },
+  /**
+   * A <Link> is used to create an <a> element that links to a route.
+   * When that route is active, the link gets an "active" class name
+   * (or the value of its `activeClassName` prop).
+   *
+   * For example, assuming you have the following route:
+   *
+   *   <Route path="/posts/:postID" component={Post} />
+   *
+   * You could use the following component to link to that route:
+   *
+   *   <Link to={`/posts/${post.id}`} />
+   *
+   * Links may pass along location state and/or query string parameters
+   * in the state/query props, respectively.
+   *
+   *   <Link ... query={{ show: true }} state={{ the: 'state' }} />
+   */
+  const Link = React.createClass({
 
-  propTypes: {
-    activeStyle: object,
-    activeClassName: string,
-    onlyActiveOnIndex: bool.isRequired,
-    to: string.isRequired,
-    query: object,
-    state: object,
-    onClick: func
-  },
+    contextTypes: {
+      history: object
+    },
 
-  getDefaultProps() {
-    return {
-      onlyActiveOnIndex: false,
-      className: '',
-      style: {}
-    }
-  },
+    propTypes: {
+      activeStyle: object,
+      activeClassName: string,
+      onlyActiveOnIndex: bool.isRequired,
+      to: string.isRequired,
+      query: object,
+      state: object,
+      onClick: func
+    },
 
-  handleClick(event) {
-    let allowTransition = true, clickResult
+    getDefaultProps() {
+      return {
+        onlyActiveOnIndex: false,
+        className: '',
+        style: {}
+      }
+    },
 
-    if (this.props.onClick)
-      clickResult = this.props.onClick(event)
+    handleClick(event) {
+      let allowTransition = true, clickResult
 
-    if (isModifiedEvent(event) || !isLeftClickEvent(event))
-      return
+      if (this.props.onClick)
+        clickResult = this.props.onClick(event)
 
-    if (clickResult === false || event.defaultPrevented === true)
-      allowTransition = false
+      if (isModifiedEvent(event) || !isLeftClickEvent(event))
+        return
 
-    event.preventDefault()
+      if (clickResult === false || event.defaultPrevented === true)
+        allowTransition = false
 
-    if (allowTransition)
-      this.context.history.pushState(this.props.state, this.props.to, this.props.query)
-  },
+      event.preventDefault()
 
-  componentWillMount() {
-    warning(
-      this.context.history,
-      'A <Link> should not be rendered outside the context of history ' +
-      'some features including real hrefs, active styling, and navigation ' +
-      'will not function correctly'
-    )
-  },
+      if (allowTransition)
+        this.context.history.pushState(this.props.state, this.props.to, this.props.query)
+    },
 
-  render() {
-    const { history } = this.context
-    const { activeClassName, activeStyle, onlyActiveOnIndex, to, query, state, onClick, ...props } = this.props
+    componentWillMount() {
+      warning(
+        this.context.history,
+        'A <Link> should not be rendered outside the context of history ' +
+        'some features including real hrefs, active styling, and navigation ' +
+        'will not function correctly'
+      )
+    },
 
-    props.onClick = this.handleClick
+    render() {
+      const { history } = this.context
+      const { activeClassName, activeStyle, onlyActiveOnIndex, to, query, state, onClick, ...props } = this.props
 
-    // Ignore if rendered outside the context
-    // of history, simplifies unit testing.
-    if (history) {
-      props.href = history.createHref(to, query)
+      props.onClick = this.handleClick
 
-      if (activeClassName || (activeStyle != null && !isEmptyObject(activeStyle))) {
-        if (history.isActive(to, query, onlyActiveOnIndex)) {
-          if (activeClassName)
-            props.className += props.className === '' ? activeClassName : ` ${activeClassName}`
+      // Ignore if rendered outside the context
+      // of history, simplifies unit testing.
+      if (history) {
+        props.href = history.createHref(to, query)
 
-          if (activeStyle)
-            props.style = { ...props.style, ...activeStyle }
+        if (activeClassName || (activeStyle != null && !isEmptyObject(activeStyle))) {
+          if (history.isActive(to, query, onlyActiveOnIndex)) {
+            if (activeClassName)
+              props.className += props.className === '' ? activeClassName : ` ${activeClassName}`
+
+            if (activeStyle)
+              props.style = { ...props.style, ...activeStyle }
+          }
         }
       }
+
+      return React.createElement('a', props)
     }
 
-    return React.createElement('a', props)
-  }
+  })
 
-})
-
-export default Link
+  return Link
+}

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -1,37 +1,40 @@
-import { PropTypes } from 'react'
+export default function createPropTypes(React) {
 
-const { func, object, arrayOf, oneOfType, element, shape, string } = PropTypes
+  const { func, object, arrayOf, oneOfType, element, shape, string } = React.PropTypes
 
-export function falsy(props, propName, componentName) {
-  if (props[propName])
-    return new Error(`<${componentName}> should not have a "${propName}" prop`)
-}
+  function falsy(props, propName, componentName) {
+    if (props[propName])
+      return new Error(`<${componentName}> should not have a "${propName}" prop`)
+  }
 
-export const history = shape({
-  listen: func.isRequired,
-  pushState: func.isRequired,
-  replaceState: func.isRequired,
-  go: func.isRequired
-})
+  const history = shape({
+    listen: func.isRequired,
+    pushState: func.isRequired,
+    replaceState: func.isRequired,
+    go: func.isRequired
+  })
 
-export const location = shape({
-  pathname: string.isRequired,
-  search: string.isRequired,
-  state: object,
-  action: string.isRequired,
-  key: string
-})
+  const location = shape({
+    pathname: string.isRequired,
+    search: string.isRequired,
+    state: object,
+    action: string.isRequired,
+    key: string
+  })
 
-export const component = oneOfType([ func, string ])
-export const components = oneOfType([ component, object ])
-export const route = oneOfType([ object, element ])
-export const routes = oneOfType([ route, arrayOf(route) ])
+  const component = oneOfType([ func, string ])
+  const components = oneOfType([ component, object ])
+  const route = oneOfType([ object, element ])
+  const routes = oneOfType([ route, arrayOf(route) ])
 
-export default {
-  falsy,
-  history,
-  location,
-  component,
-  components,
-  route
+  return {
+    falsy,
+    history,
+    location,
+    component,
+    components,
+    route,
+    routes
+  }
+
 }

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -1,67 +1,73 @@
-import React from 'react'
 import invariant from 'invariant'
-import { createRouteFromReactElement } from './RouteUtils'
+import createRouteUtils from './RouteUtils'
 import { formatPattern } from './PatternUtils'
-import { falsy } from './PropTypes'
+import createPropTypes from './PropTypes'
 
-const { string, object } = React.PropTypes
+export default function createRedirect(React) {
+  const { createRouteFromReactElement } = createRouteUtils(React)
 
-/**
- * A <Redirect> is used to declare another URL path a client should be sent
- * to when they request a given URL.
- *
- * Redirects are placed alongside routes in the route configuration and are
- * traversed in the same manner.
- */
-const Redirect = React.createClass({
+  const { falsy } = createPropTypes(React)
 
-  statics: {
+  const { string, object } = React.PropTypes
 
-    createRouteFromReactElement(element) {
-      const route = createRouteFromReactElement(element)
+  /**
+   * A <Redirect> is used to declare another URL path a client should be sent
+   * to when they request a given URL.
+   *
+   * Redirects are placed alongside routes in the route configuration and are
+   * traversed in the same manner.
+   */
+  const Redirect = React.createClass({
 
-      if (route.from)
-        route.path = route.from
+    statics: {
 
-      // TODO: Handle relative pathnames, see #1658
-      invariant(
-        route.to.charAt(0) === '/',
-        '<Redirect to> must be an absolute path. This should be fixed in the future'
-      )
+      createRouteFromReactElement(element) {
+        const route = createRouteFromReactElement(element)
 
-      route.onEnter = function (nextState, replaceState) {
-        const { location, params } = nextState
-        const pathname = route.to ? formatPattern(route.to, params) : location.pathname
+        if (route.from)
+          route.path = route.from
 
-        replaceState(
-          route.state || location.state,
-          pathname,
-          route.query || location.query
+        // TODO: Handle relative pathnames, see #1658
+        invariant(
+          route.to.charAt(0) === '/',
+          '<Redirect to> must be an absolute path. This should be fixed in the future'
         )
+
+        route.onEnter = function (nextState, replaceState) {
+          const { location, params } = nextState
+          const pathname = route.to ? formatPattern(route.to, params) : location.pathname
+
+          replaceState(
+            route.state || location.state,
+            pathname,
+            route.query || location.query
+          )
+        }
+
+        return route
       }
 
-      return route
+    },
+
+    propTypes: {
+      path: string,
+      from: string, // Alias for path
+      to: string.isRequired,
+      query: object,
+      state: object,
+      onEnter: falsy,
+      children: falsy
+    },
+
+    render() {
+      invariant(
+        false,
+        '<Redirect> elements are for router configuration only and should not be rendered'
+      )
     }
 
-  },
+  })
 
-  propTypes: {
-    path: string,
-    from: string, // Alias for path
-    to: string.isRequired,
-    query: object,
-    state: object,
-    onEnter: falsy,
-    children: falsy
-  },
+  return Redirect
 
-  render() {
-    invariant(
-      false,
-      '<Redirect> elements are for router configuration only and should not be rendered'
-    )
-  }
-
-})
-
-export default Redirect
+}

--- a/modules/Route.js
+++ b/modules/Route.js
@@ -1,59 +1,66 @@
-import React from 'react'
 import warning from 'warning'
 import invariant from 'invariant'
-import { createRouteFromReactElement } from './RouteUtils'
-import { component, components } from './PropTypes'
 
-const { string, bool, func } = React.PropTypes
+import createRouteUtils from './RouteUtils'
+import createPropTypes from './PropTypes'
 
-/**
- * A <Route> is used to declare which components are rendered to the page when
- * the URL matches a given pattern.
- *
- * Routes are arranged in a nested tree structure. When a new URL is requested,
- * the tree is searched depth-first to find a route whose path matches the URL.
- * When one is found, all routes in the tree that lead to it are considered
- * "active" and their components are rendered into the DOM, nested in the same
- * order as they are in the tree.
- */
-const Route = React.createClass({
+export default function createRoute(React) {
 
-  statics: {
+  const { createRouteFromReactElement } = createRouteUtils(React)
+  const { component, components } = createPropTypes(React)
 
-    createRouteFromReactElement(element) {
-      const route = createRouteFromReactElement(element)
+  const { string, bool, func } = React.PropTypes
 
-      if (route.handler) {
-        warning(
-          false,
-          '<Route handler> is deprecated, use <Route component> instead'
-        )
+  /**
+   * A <Route> is used to declare which components are rendered to the page when
+   * the URL matches a given pattern.
+   *
+   * Routes are arranged in a nested tree structure. When a new URL is requested,
+   * the tree is searched depth-first to find a route whose path matches the URL.
+   * When one is found, all routes in the tree that lead to it are considered
+   * "active" and their components are rendered into the DOM, nested in the same
+   * order as they are in the tree.
+   */
+  const Route = React.createClass({
 
-        route.component = route.handler
-        delete route.handler
+    statics: {
+
+      createRouteFromReactElement(element) {
+        const route = createRouteFromReactElement(element)
+
+        if (route.handler) {
+          warning(
+            false,
+            '<Route handler> is deprecated, use <Route component> instead'
+          )
+
+          route.component = route.handler
+          delete route.handler
+        }
+
+        return route
       }
 
-      return route
+    },
+
+    propTypes: {
+      path: string,
+      ignoreScrollBehavior: bool,
+      handler: component, // deprecated
+      component,
+      components,
+      getComponents: func
+    },
+
+    render() {
+      invariant(
+        false,
+        '<Route> elements are for router configuration only and should not be rendered'
+      )
     }
-  
-  },
 
-  propTypes: {
-    path: string,
-    ignoreScrollBehavior: bool,
-    handler: component, // deprecated
-    component,
-    components,
-    getComponents: func
-  },
+  })
 
-  render() {
-    invariant(
-      false,
-      '<Route> elements are for router configuration only and should not be rendered'
-    )
-  }
+  return Route
 
-})
-
-export default Route
+}

--- a/modules/RouteContext.js
+++ b/modules/RouteContext.js
@@ -1,29 +1,31 @@
-import React from 'react'
+export default function createRouteContext(React) {
 
-const { object } = React.PropTypes
+  const { object } = React.PropTypes
 
-/**
- * The RouteContext mixin provides a convenient way for route
- * components to set the route in context. This is needed for
- * routes that render elements that want to use the Lifecycle
- * mixin to prevent transitions.
- */
-const RouteContext = {
+  /**
+   * The RouteContext mixin provides a convenient way for route
+   * components to set the route in context. This is needed for
+   * routes that render elements that want to use the Lifecycle
+   * mixin to prevent transitions.
+   */
+  const RouteContext = {
 
-  propTypes: {
-    route: object.isRequired
-  },
+    propTypes: {
+      route: object.isRequired
+    },
 
-  childContextTypes: {
-    route: object.isRequired
-  },
+    childContextTypes: {
+      route: object.isRequired
+    },
 
-  getChildContext() {
-    return {
-      route: this.props.route
+    getChildContext() {
+      return {
+        route: this.props.route
+      }
     }
+
   }
 
-}
+  return RouteContext
 
-export default RouteContext
+}

--- a/modules/RouteUtils.js
+++ b/modules/RouteUtils.js
@@ -1,97 +1,107 @@
-import React from 'react'
 import warning from 'warning'
 
-function isValidChild(object) {
-  return object == null || React.isValidElement(object)
-}
+export default function createRouteUtils(React) {
 
-export function isReactChildren(object) {
-  return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild))
-}
-
-function checkPropTypes(componentName, propTypes, props) {
-  componentName = componentName || 'UnknownComponent'
-
-  for (const propName in propTypes) {
-    if (propTypes.hasOwnProperty(propName)) {
-      const error = propTypes[propName](props, propName, componentName)
-
-      if (error instanceof Error)
-        warning(false, error.message)
-    }
-  }
-}
-
-function createRoute(defaultProps, props) {
-  return { ...defaultProps, ...props }
-}
-
-export function createRouteFromReactElement(element) {
-  const type = element.type
-  const route = createRoute(type.defaultProps, element.props)
-
-  if (type.propTypes)
-    checkPropTypes(type.displayName || type.name, type.propTypes, route)
-
-  if (route.children) {
-    const childRoutes = createRoutesFromReactChildren(route.children, route)
-
-    if (childRoutes.length)
-      route.childRoutes = childRoutes
-
-    delete route.children
+  function isValidChild(object) {
+    return object == null || React.isValidElement(object)
   }
 
-  return route
-}
+  function isReactChildren(object) {
+    return isValidChild(object) || (Array.isArray(object) && object.every(isValidChild))
+  }
 
-/**
- * Creates and returns a routes object from the given ReactChildren. JSX
- * provides a convenient way to visualize how routes in the hierarchy are
- * nested.
- *
- *   import { Route, createRoutesFromReactChildren } from 'react-router'
- *   
- *   const routes = createRoutesFromReactChildren(
- *     <Route component={App}>
- *       <Route path="home" component={Dashboard}/>
- *       <Route path="news" component={NewsFeed}/>
- *     </Route>
- *   )
- *
- * Note: This method is automatically used when you provide <Route> children
- * to a <Router> component.
- */
-export function createRoutesFromReactChildren(children, parentRoute) {
-  const routes = []
+  function checkPropTypes(componentName, propTypes, props) {
+    componentName = componentName || 'UnknownComponent'
 
-  React.Children.forEach(children, function (element) {
-    if (React.isValidElement(element)) {
-      // Component classes may have a static create* method.
-      if (element.type.createRouteFromReactElement) {
-        const route = element.type.createRouteFromReactElement(element, parentRoute)
+    for (const propName in propTypes) {
+      if (propTypes.hasOwnProperty(propName)) {
+        const error = propTypes[propName](props, propName, componentName)
 
-        if (route)
-          routes.push(route)
-      } else {
-        routes.push(createRouteFromReactElement(element))
+        if (error instanceof Error)
+          warning(false, error.message)
       }
     }
-  })
-
-  return routes
-}
-
-/**
- * Creates and returns an array of routes from the given object which
- * may be a JSX route, a plain object route, or an array of either.
- */
-export function createRoutes(routes) {
-  if (isReactChildren(routes)) {
-    routes = createRoutesFromReactChildren(routes)
-  } else if (!Array.isArray(routes)) {
-    routes = [ routes ]
   }
 
-  return routes
+  function createRoute(defaultProps, props) {
+    return { ...defaultProps, ...props }
+  }
+
+  function createRouteFromReactElement(element) {
+    const type = element.type
+    const route = createRoute(type.defaultProps, element.props)
+
+    if (type.propTypes)
+      checkPropTypes(type.displayName || type.name, type.propTypes, route)
+
+    if (route.children) {
+      const childRoutes = createRoutesFromReactChildren(route.children, route)
+
+      if (childRoutes.length)
+        route.childRoutes = childRoutes
+
+      delete route.children
+    }
+
+    return route
+  }
+
+  /**
+   * Creates and returns a routes object from the given ReactChildren. JSX
+   * provides a convenient way to visualize how routes in the hierarchy are
+   * nested.
+   *
+   *   import { Route, createRoutesFromReactChildren } from 'react-router'
+   *
+   *   const routes = createRoutesFromReactChildren(
+   *     <Route component={App}>
+   *       <Route path="home" component={Dashboard}/>
+   *       <Route path="news" component={NewsFeed}/>
+   *     </Route>
+   *   )
+   *
+   * Note: This method is automatically used when you provide <Route> children
+   * to a <Router> component.
+   */
+  function createRoutesFromReactChildren(children, parentRoute) {
+    const routes = []
+
+    React.Children.forEach(children, function (element) {
+      if (React.isValidElement(element)) {
+        // Component classes may have a static create* method.
+        if (element.type.createRouteFromReactElement) {
+          const route = element.type.createRouteFromReactElement(element, parentRoute)
+
+          if (route)
+            routes.push(route)
+        } else {
+          routes.push(createRouteFromReactElement(element))
+        }
+      }
+    })
+
+    return routes
+  }
+
+  /**
+   * Creates and returns an array of routes from the given object which
+   * may be a JSX route, a plain object route, or an array of either.
+   */
+  function createRoutes(routes) {
+    if (isReactChildren(routes)) {
+      routes = createRoutesFromReactChildren(routes)
+    } else if (!Array.isArray(routes)) {
+      routes = [ routes ]
+    }
+
+    return routes
+  }
+
+  return {
+    isReactChildren,
+    createRouteFromReactElement,
+    createRoutesFromReactChildren,
+    createRoutes
+  }
+
 }

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -1,97 +1,102 @@
-import React from 'react'
 import warning from 'warning'
 import createHashHistory from 'history/lib/createHashHistory'
-import { createRoutes } from './RouteUtils'
-import RoutingContext from './RoutingContext'
-import useRoutes from './useRoutes'
-import { routes } from './PropTypes'
+import createRouteUtils from './RouteUtils'
+import createRoutingContext from './RoutingContext'
+import createUseRoutes from './useRoutes'
+import createPropTypes from './PropTypes'
 
-const { func, object } = React.PropTypes
+export default function createRouter(React) {
+  const { createRoutes } = createRouteUtils(React)
+  const RoutingContext = createRoutingContext(React)
+  const useRoutes = createUseRoutes(React)
+  const { routes } = createPropTypes(React)
+  const { func, object } = React.PropTypes
 
-/**
- * A <Router> is a high-level API for automatically setting up
- * a router that renders a <RoutingContext> with all the props
- * it needs each time the URL changes.
- */
-const Router = React.createClass({
+  /**
+   * A <Router> is a high-level API for automatically setting up
+   * a router that renders a <RoutingContext> with all the props
+   * it needs each time the URL changes.
+   */
+  const Router = React.createClass({
 
-  propTypes: {
-    history: object,
-    children: routes,
-    routes, // alias for children
-    createElement: func,
-    onError: func,
-    onUpdate: func,
-    parseQueryString: func,
-    stringifyQuery: func
-  },
+    propTypes: {
+      history: object,
+      children: routes,
+      routes, // alias for children
+      createElement: func,
+      onError: func,
+      onUpdate: func,
+      parseQueryString: func,
+      stringifyQuery: func
+    },
 
-  getInitialState() {
-    return {
-      location: null,
-      routes: null,
-      params: null,
-      components: null
-    }
-  },
-
-  handleError(error) {
-    if (this.props.onError) {
-      this.props.onError.call(this, error)
-    } else {
-      // Throw errors by default so we don't silently swallow them!
-      throw error // This error probably occurred in getChildRoutes or getComponents.
-    }
-  },
-
-  componentWillMount() {
-    let { history, children, routes, parseQueryString, stringifyQuery } = this.props
-    let createHistory = history ? () => history : createHashHistory
-
-    this.history = useRoutes(createHistory)({
-      routes: createRoutes(routes || children),
-      parseQueryString,
-      stringifyQuery
-    })
-
-    this._unlisten = this.history.listen((error, state) => {
-      if (error) {
-        this.handleError(error)
-      } else {
-        this.setState(state, this.props.onUpdate)
+    getInitialState() {
+      return {
+        location: null,
+        routes: null,
+        params: null,
+        components: null
       }
-    })
-  },
+    },
 
-  componentWillReceiveProps(nextProps) {
-    warning(
-      nextProps.history === this.props.history,
-      "The `history` provided to <Router/> has changed, it will be ignored."
-    )
-  },
+    handleError(error) {
+      if (this.props.onError) {
+        this.props.onError.call(this, error)
+      } else {
+        // Throw errors by default so we don't silently swallow them!
+        throw error // This error probably occurred in getChildRoutes or getComponents.
+      }
+    },
 
-  componentWillUnmount() {
-    if (this._unlisten)
-      this._unlisten()
-  },
+    componentWillMount() {
+      let { history, children, routes, parseQueryString, stringifyQuery } = this.props
+      let createHistory = history ? () => history : createHashHistory
 
-  render() {
-    let { location, routes, params, components } = this.state
-    let { createElement } = this.props
+      this.history = useRoutes(createHistory)({
+        routes: createRoutes(routes || children),
+        parseQueryString,
+        stringifyQuery
+      })
 
-    if (location == null)
-      return null // Async match
+      this._unlisten = this.history.listen((error, state) => {
+        if (error) {
+          this.handleError(error)
+        } else {
+          this.setState(state, this.props.onUpdate)
+        }
+      })
+    },
 
-    return React.createElement(RoutingContext, {
-      history: this.history,
-      createElement,
-      location,
-      routes,
-      params,
-      components
-    })
-  }
+    componentWillReceiveProps(nextProps) {
+      warning(
+        nextProps.history === this.props.history,
+        "The `history` provided to <Router/> has changed, it will be ignored."
+      )
+    },
 
-})
+    componentWillUnmount() {
+      if (this._unlisten)
+        this._unlisten()
+    },
 
-export default Router
+    render() {
+      let { location, routes, params, components } = this.state
+      let { createElement } = this.props
+
+      if (location == null)
+        return null // Async match
+
+      return React.createElement(RoutingContext, {
+        history: this.history,
+        createElement,
+        location,
+        routes,
+        params,
+        components
+      })
+    }
+
+  })
+
+  return Router
+}

--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -1,91 +1,94 @@
-import React from 'react'
 import invariant from 'invariant'
 import getRouteParams from './getRouteParams'
 
-const { array, func, object } = React.PropTypes
+export default function createRoutingContext(React) {
 
-/**
- * A <RoutingContext> renders the component tree for a given router state
- * and sets the history object and the current location in context.
- */
-const RoutingContext = React.createClass({
+  const { array, func, object } = React.PropTypes
 
-  propTypes: {
-    history: object.isRequired,
-    createElement: func.isRequired,
-    location: object.isRequired,
-    routes: array.isRequired,
-    params: object.isRequired,
-    components: array.isRequired
-  },
+  /**
+   * A <RoutingContext> renders the component tree for a given router state
+   * and sets the history object and the current location in context.
+   */
+  const RoutingContext = React.createClass({
 
-  getDefaultProps() {
-    return {
-      createElement: React.createElement
+    propTypes: {
+      history: object.isRequired,
+      createElement: func.isRequired,
+      location: object.isRequired,
+      routes: array.isRequired,
+      params: object.isRequired,
+      components: array.isRequired
+    },
+
+    getDefaultProps() {
+      return {
+        createElement: React.createElement
+      }
+    },
+
+    childContextTypes: {
+      history: object.isRequired,
+      location: object.isRequired
+    },
+
+    getChildContext() {
+      return {
+        history: this.props.history,
+        location: this.props.location
+      }
+    },
+
+    createElement(component, props) {
+      return component == null ? null : this.props.createElement(component, props)
+    },
+
+    render() {
+      const { history, location, routes, params, components } = this.props
+      let element = null
+
+      if (components) {
+        element = components.reduceRight((element, components, index) => {
+          if (components == null)
+            return element // Don't create new children use the grandchildren.
+
+          const route = routes[index]
+          const routeParams = getRouteParams(route, params)
+          const props = {
+            history,
+            location,
+            params,
+            route,
+            routeParams,
+            routes
+          }
+
+          if (element)
+            props.children = element
+
+          if (typeof components === 'object') {
+            const elements = {}
+
+            for (const key in components)
+              if (components.hasOwnProperty(key))
+                elements[key] = this.createElement(components[key], props)
+
+            return elements
+          }
+
+          return this.createElement(components, props)
+        }, element)
+      }
+
+      invariant(
+        element === null || element === false || React.isValidElement(element),
+        'The root route must render a single element'
+      )
+
+      return element
     }
-  },
 
-  childContextTypes: {
-    history: object.isRequired,
-    location: object.isRequired
-  },
+  })
 
-  getChildContext() {
-    return {
-      history: this.props.history,
-      location: this.props.location
-    }
-  },
+  return RoutingContext
 
-  createElement(component, props) {
-    return component == null ? null : this.props.createElement(component, props)
-  },
-
-  render() {
-    const { history, location, routes, params, components } = this.props
-    let element = null
-
-    if (components) {
-      element = components.reduceRight((element, components, index) => {
-        if (components == null)
-          return element // Don't create new children use the grandchildren.
-
-        const route = routes[index]
-        const routeParams = getRouteParams(route, params)
-        const props = {
-          history,
-          location,
-          params,
-          route,
-          routeParams,
-          routes
-        }
-
-        if (element)
-          props.children = element
-
-        if (typeof components === 'object') {
-          const elements = {}
-
-          for (const key in components)
-            if (components.hasOwnProperty(key))
-              elements[key] = this.createElement(components[key], props)
-
-          return elements
-        }
-
-        return this.createElement(components, props)
-      }, element)
-    }
-
-    invariant(
-      element === null || element === false || React.isValidElement(element),
-      'The root route must render a single element'
-    )
-
-    return element
-  }
-
-})
-
-export default RoutingContext
+}

--- a/modules/__tests__/History-test.js
+++ b/modules/__tests__/History-test.js
@@ -1,10 +1,15 @@
 /*eslint-env mocha */
 import expect from 'expect'
 import React from 'react'
-import History from '../History'
-import Router from '../Router'
-import Route from '../Route'
-import createHistory from 'history/lib/createMemoryHistory'
+import createHistory from '../History'
+import createRouter from '../Router'
+import createRoute from '../Route'
+import createMemoryHistory from 'history/lib/createMemoryHistory'
+
+const History = createHistory(React)
+const Router = createRouter(React)
+const Route = createRoute(React)
+
 
 describe('History Mixin', function () {
 
@@ -18,7 +23,7 @@ describe('History Mixin', function () {
   })
 
   it('assigns the history to the component instance', function (done) {
-    let history = createHistory('/')
+    let history = createMemoryHistory('/')
 
     function assertHistory() {
       expect(this.history).toExist()

--- a/modules/__tests__/IndexRoute-test.js
+++ b/modules/__tests__/IndexRoute-test.js
@@ -3,9 +3,13 @@
 import expect from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
-import IndexRoute from '../IndexRoute'
-import Router from '../Router'
-import Route from '../Route'
+import createIndexRoute from '../IndexRoute'
+import createRouter from '../Router'
+import createRoute from '../Route'
+
+const IndexRoute = createIndexRoute(React)
+const Router = createRouter(React)
+const Route = createRoute(React)
 
 describe('an <IndexRoute/>', function () {
 

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -5,9 +5,13 @@ import expect from 'expect'
 import React from 'react/addons'
 import createHistory from 'history/lib/createMemoryHistory'
 import execSteps from './execSteps'
-import Router from '../Router'
-import Route from '../Route'
-import Link from '../Link'
+import createRouter from '../Router'
+import createRoute from '../Route'
+import createLink from '../Link'
+
+const Router = createRouter(React)
+const Route = createRoute(React)
+const Link = createLink(React)
 
 const { click } = React.addons.TestUtils.Simulate
 

--- a/modules/__tests__/Redirect-test.js
+++ b/modules/__tests__/Redirect-test.js
@@ -2,9 +2,13 @@
 import expect from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
-import Redirect from '../Redirect'
-import Router from '../Router'
-import Route from '../Route'
+import createRedirect from '../Redirect'
+import createRouter from '../Router'
+import createRoute from '../Route'
+
+const Redirect = createRedirect(React)
+const Router = createRouter(React)
+const Route = createRoute(React)
 
 describe('A <Redirect>', function () {
 

--- a/modules/__tests__/RouteComponent-test.js
+++ b/modules/__tests__/RouteComponent-test.js
@@ -2,7 +2,9 @@
 import expect from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
-import Router from '../Router'
+import createRouter from '../Router'
+
+const Router = createRouter(React)
 
 describe('a Route Component', function () {
 

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -3,8 +3,11 @@
 import expect from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
-import Router from '../Router'
-import Route from '../Route'
+import createRouter from '../Router'
+import createRoute from '../Route'
+
+const Router = createRouter(React)
+const Route = createRoute(React)
 
 describe('Router', function () {
 

--- a/modules/__tests__/createRoutesFromReactChildren-test.js
+++ b/modules/__tests__/createRoutesFromReactChildren-test.js
@@ -2,9 +2,13 @@
 /*eslint react/prop-types: 0*/
 import expect from 'expect'
 import React from 'react'
-import { createRoutesFromReactChildren } from '../RouteUtils'
-import IndexRoute from '../IndexRoute'
-import Route from '../Route'
+import createRouteUtils from '../RouteUtils'
+import createIndexRoute from '../IndexRoute'
+import createRoute from '../Route'
+
+const Route = createRoute(React)
+const IndexRoute = createIndexRoute(React)
+const { createRoutesFromReactChildren } = createRouteUtils(React)
 
 describe('createRoutesFromReactChildren', function () {
 

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -2,9 +2,13 @@
 import expect from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
-import IndexRoute from '../IndexRoute'
-import Router from '../Router'
-import Route from '../Route'
+import createIndexRoute from '../IndexRoute'
+import createRouter from '../Router'
+import createRoute from '../Route'
+
+const IndexRoute = createIndexRoute(React)
+const Router = createRouter(React)
+const Route = createRoute(React)
 
 describe('isActive', function () {
 

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -1,12 +1,16 @@
 /*eslint-env mocha */
 import React from 'react'
-import Route from '../Route'
+import createRoute from '../Route'
 
 import assert from 'assert'
 import expect from 'expect'
 import { createLocation } from 'history'
-import { createRoutes } from '../RouteUtils'
-import matchRoutes from '../matchRoutes'
+import createRouteUtils from '../RouteUtils'
+import createMatchRoutes from '../matchRoutes'
+
+const Route = createRoute(React)
+const { createRoutes } = createRouteUtils(React)
+const matchRoutes = createMatchRoutes(React)
 
 describe('matchRoutes', function () {
 

--- a/modules/__tests__/pushState-test.js
+++ b/modules/__tests__/pushState-test.js
@@ -3,8 +3,11 @@ import expect from 'expect'
 import React from 'react'
 import resetHash from './resetHash'
 import execSteps from './execSteps'
-import Router from '../Router'
-import Route from '../Route'
+import createRouter from '../Router'
+import createRoute from '../Route'
+
+const Router = createRouter(React)
+const Route = createRoute(React)
 
 describe('pushState', function () {
   beforeEach(resetHash)

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -3,9 +3,13 @@
 import expect from 'expect'
 import React from 'react'
 import createLocation from 'history/lib/createLocation'
-import RoutingContext from '../RoutingContext'
-import match from '../match'
-import Link from '../Link'
+import createRoutingContext from '../RoutingContext'
+import createMatch from '../match'
+import createLink from '../Link'
+
+const RoutingContext = createRoutingContext(React)
+const match = createMatch(React)
+const Link = createLink(React)
 
 describe('server rendering', function () {
 

--- a/modules/__tests__/transitionHooks-test.js
+++ b/modules/__tests__/transitionHooks-test.js
@@ -4,7 +4,9 @@ import expect, { spyOn } from 'expect'
 import React from 'react'
 import createHistory from 'history/lib/createMemoryHistory'
 import execSteps from './execSteps'
-import Router from '../Router'
+import createRouter from '../Router'
+
+const Router = createRouter(React)
 
 describe('When a router enters a branch', function () {
 

--- a/modules/createAll.js
+++ b/modules/createAll.js
@@ -1,0 +1,54 @@
+import createRouter from './Router'
+import createLink from './Link'
+import createIndexLink from './IndexLink'
+import createIndexRoute from './IndexRoute'
+import createRedirect from './Redirect';
+import createRoute from './Route'
+import createHistory from './History'
+import createLifecycle from './Lifecycle'
+import createRouteContext from './RouteContext'
+import createUseRoutes from './useRoutes'
+import createRouteUtils from './RouteUtils'
+import createRoutingContext from './RoutingContext'
+import createPropTypes from './PropTypes'
+import createMatch from './match'
+
+
+export default function createAll(React) {
+  const Router = createRouter(React)
+  const Link = createLink(React)
+  const IndexLink = createIndexLink(React)
+  const IndexRoute = createIndexRoute(React)
+  const Redirect = createRedirect(React)
+  const Route = createRoute(React)
+  const History = createHistory(React)
+  const Lifecycle = createLifecycle(React)
+  const RouteContext = createRouteContext(React)
+  const useRoutes = createUseRoutes(React)
+  const { createRoutes } = createRouteUtils(React)
+  const RoutingContext = createRoutingContext(React)
+  const PropTypes = createPropTypes(React)
+  const match = createMatch(React)
+
+  return {
+    /* components */
+    Router,
+    Link,
+    IndexLink,
+    /* components (configuration) */
+    IndexRoute,
+    Redirect,
+    Route,
+    /* mixins */
+    History,
+    Lifecycle,
+    RouteContext,
+
+    /* utils */
+    useRoutes,
+    createRoutes,
+    RoutingContext,
+    PropTypes,
+    match
+  }
+}

--- a/modules/match.js
+++ b/modules/match.js
@@ -1,25 +1,32 @@
 import createMemoryHistory from 'history/lib/createMemoryHistory'
-import useRoutes from './useRoutes'
-import { createRoutes } from './RouteUtils'
+import createUseRoutes from './useRoutes'
+import createRouteUtils from './RouteUtils'
 
-export default function match({
-  routes,
-  history,
-  location,
-  parseQueryString,
-  stringifyQuery
-}, cb) {
-  let createHistory = history ? () => history : createMemoryHistory
+export default function createMatch(React) {
 
-  let staticHistory = useRoutes(createHistory)({
-    routes: createRoutes(routes),
+  const useRoutes = createUseRoutes(React);
+  const { createRoutes } = createRouteUtils(React)
+
+  function match({
+    routes,
+    history,
+    location,
     parseQueryString,
     stringifyQuery
-  })
+  }, cb) {
+    let createHistory = history ? () => history : createMemoryHistory
 
-  staticHistory.match(location, function (error, nextLocation, nextState) {
-    let renderProps = nextState ? {...nextState, history: staticHistory} : null
-    cb(error, nextLocation, renderProps)
-  })
+    let staticHistory = useRoutes(createHistory)({
+      routes: createRoutes(routes),
+      parseQueryString,
+      stringifyQuery
+    })
+
+    staticHistory.match(location, function (error, nextLocation, nextState) {
+      let renderProps = nextState ? {...nextState, history: staticHistory} : null
+      cb(error, nextLocation, renderProps)
+    })
+  }
+
+  return match
 }
-

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -1,126 +1,132 @@
 import { loopAsync } from './AsyncUtils'
 import { matchPattern } from './PatternUtils'
-import { createRoutes } from './RouteUtils'
+import createRouteUtils from './RouteUtils'
 
-function getChildRoutes(route, location, callback) {
-  if (route.childRoutes) {
-    callback(null, route.childRoutes)
-  } else if (route.getChildRoutes) {
-    route.getChildRoutes(location, function(error, childRoutes) {
-        callback(error, !error && createRoutes(childRoutes))
-    })
-  } else {
-    callback()
-  }
-}
+export default function createMatchRoutes(React) {
 
-function getIndexRoute(route, location, callback) {
-  if (route.indexRoute) {
-    callback(null, route.indexRoute)
-  } else if (route.getIndexRoute) {
-    route.getIndexRoute(location, function(error, indexRoute) {
-        callback(error, !error && createRoutes(indexRoute)[0])
-    })
-  } else {
-    callback()
-  }
-}
+  const { createRoutes } = createRouteUtils(React)
 
-function assignParams(params, paramNames, paramValues) {
-  return paramNames.reduceRight(function (params, paramName, index) {
-    const paramValue = paramValues && paramValues[index]
-
-    if (Array.isArray(params[paramName])) {
-      params[paramName].unshift(paramValue)
-    } else if (paramName in params) {
-      params[paramName] = [ paramValue, params[paramName] ]
+  function getChildRoutes(route, location, callback) {
+    if (route.childRoutes) {
+      callback(null, route.childRoutes)
+    } else if (route.getChildRoutes) {
+      route.getChildRoutes(location, function(error, childRoutes) {
+          callback(error, !error && createRoutes(childRoutes))
+      })
     } else {
-      params[paramName] = paramValue
+      callback()
     }
-
-    return params
-  }, params)
-}
-
-function createParams(paramNames, paramValues) {
-  return assignParams({}, paramNames, paramValues)
-}
-
-function matchRouteDeep(basename, route, location, callback) {
-  let pattern = route.path || ''
-
-  if (pattern.indexOf('/') !== 0)
-    pattern = basename.replace(/\/*$/, '/') + pattern // Relative paths build on the parent's path.
-
-  const { remainingPathname, paramNames, paramValues } = matchPattern(pattern, location.pathname)
-  const isExactMatch = remainingPathname === ''
-
-  if (isExactMatch && route.path) {
-    const match = {
-      routes: [ route ],
-      params: createParams(paramNames, paramValues)
-    }
-
-    getIndexRoute(route, location, function (error, indexRoute) {
-      if (error) {
-        callback(error)
-      } else {
-        if (indexRoute)
-          match.routes.push(indexRoute)
-
-        callback(null, match)
-      }
-    })
-  } else if (remainingPathname != null || route.childRoutes) {
-    // Either a) this route matched at least some of the path or b)
-    // we don't have to load this route's children asynchronously. In
-    // either case continue checking for matches in the subtree.
-    getChildRoutes(route, location, function (error, childRoutes) {
-      if (error) {
-        callback(error)
-      } else if (childRoutes) {
-        // Check the child routes to see if any of them match.
-        matchRoutes(childRoutes, location, function (error, match) {
-          if (error) {
-            callback(error)
-          } else if (match) {
-            // A child route matched! Augment the match and pass it up the stack.
-            match.routes.unshift(route)
-            callback(null, match)
-          } else {
-            callback()
-          }
-        }, pattern)
-      } else {
-        callback()
-      }
-    })
-  } else {
-    callback()
   }
-}
 
-/**
- * Asynchronously matches the given location to a set of routes and calls
- * callback(error, state) when finished. The state object will have the
- * following properties:
- *
- * - routes       An array of routes that matched, in hierarchical order
- * - params       An object of URL parameters
- *
- * Note: This operation may finish synchronously if no routes have an
- * asynchronous getChildRoutes method.
- */
-function matchRoutes(routes, location, callback, basename='') {
-  loopAsync(routes.length, function (index, next, done) {
-    matchRouteDeep(basename, routes[index], location, function (error, match) {
-      if (error || match) {
-        done(error, match)
+  function getIndexRoute(route, location, callback) {
+    if (route.indexRoute) {
+      callback(null, route.indexRoute)
+    } else if (route.getIndexRoute) {
+      route.getIndexRoute(location, function(error, indexRoute) {
+          callback(error, !error && createRoutes(indexRoute)[0])
+      })
+    } else {
+      callback()
+    }
+  }
+
+  function assignParams(params, paramNames, paramValues) {
+    return paramNames.reduceRight(function (params, paramName, index) {
+      const paramValue = paramValues && paramValues[index]
+
+      if (Array.isArray(params[paramName])) {
+        params[paramName].unshift(paramValue)
+      } else if (paramName in params) {
+        params[paramName] = [ paramValue, params[paramName] ]
       } else {
-        next()
+        params[paramName] = paramValue
       }
-    })
-  }, callback)
-}
 
-export default matchRoutes
+      return params
+    }, params)
+  }
+
+  function createParams(paramNames, paramValues) {
+    return assignParams({}, paramNames, paramValues)
+  }
+
+  function matchRouteDeep(basename, route, location, callback) {
+    let pattern = route.path || ''
+
+    if (pattern.indexOf('/') !== 0)
+      pattern = basename.replace(/\/*$/, '/') + pattern // Relative paths build on the parent's path.
+
+    const { remainingPathname, paramNames, paramValues } = matchPattern(pattern, location.pathname)
+    const isExactMatch = remainingPathname === ''
+
+    if (isExactMatch && route.path) {
+      const match = {
+        routes: [ route ],
+        params: createParams(paramNames, paramValues)
+      }
+
+      getIndexRoute(route, location, function (error, indexRoute) {
+        if (error) {
+          callback(error)
+        } else {
+          if (indexRoute)
+            match.routes.push(indexRoute)
+
+          callback(null, match)
+        }
+      })
+    } else if (remainingPathname != null || route.childRoutes) {
+      // Either a) this route matched at least some of the path or b)
+      // we don't have to load this route's children asynchronously. In
+      // either case continue checking for matches in the subtree.
+      getChildRoutes(route, location, function (error, childRoutes) {
+        if (error) {
+          callback(error)
+        } else if (childRoutes) {
+          // Check the child routes to see if any of them match.
+          matchRoutes(childRoutes, location, function (error, match) {
+            if (error) {
+              callback(error)
+            } else if (match) {
+              // A child route matched! Augment the match and pass it up the stack.
+              match.routes.unshift(route)
+              callback(null, match)
+            } else {
+              callback()
+            }
+          }, pattern)
+        } else {
+          callback()
+        }
+      })
+    } else {
+      callback()
+    }
+  }
+
+  /**
+   * Asynchronously matches the given location to a set of routes and calls
+   * callback(error, state) when finished. The state object will have the
+   * following properties:
+   *
+   * - routes       An array of routes that matched, in hierarchical order
+   * - params       An object of URL parameters
+   *
+   * Note: This operation may finish synchronously if no routes have an
+   * asynchronous getChildRoutes method.
+   */
+  function matchRoutes(routes, location, callback, basename='') {
+    loopAsync(routes.length, function (index, next, done) {
+      matchRouteDeep(basename, routes[index], location, function (error, match) {
+        if (error || match) {
+          done(error, match)
+        } else {
+          next()
+        }
+      })
+    }, callback)
+  }
+
+  return matchRoutes
+
+}

--- a/modules/native.js
+++ b/modules/native.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react-native'
 import createAll from './createAll'
 
 const all = createAll(React)

--- a/modules/useRoutes.js
+++ b/modules/useRoutes.js
@@ -6,235 +6,241 @@ import computeChangedRoutes from './computeChangedRoutes'
 import { runEnterHooks, runLeaveHooks } from './TransitionUtils'
 import { default as _isActive } from './isActive'
 import getComponents from './getComponents'
-import matchRoutes from './matchRoutes'
+import createMatchRoutes from './matchRoutes'
 
-function hasAnyProperties(object) {
-  for (const p in object)
-    if (object.hasOwnProperty(p))
-      return true
+export default function createUseRoutes(React) {
 
-  return false
-}
+  const matchRoutes = createMatchRoutes(React)
 
-/**
- * Returns a new createHistory function that may be used to create
- * history objects that know about routing.
- *
- * - isActive(pathname, query)
- * - registerRouteHook(route, (location) => {})
- * - unregisterRouteHook(route, (location) => {})
- * - match(location, (error, nextState, nextLocation) => {})
- * - listen((error, nextState) => {})
- */
-function useRoutes(createHistory) {
-  return function (options={}) {
-    let { routes, ...historyOptions } = options
-    let history = useQueries(createHistory)(historyOptions)
-    let state = {}
+  function hasAnyProperties(object) {
+    for (const p in object)
+      if (object.hasOwnProperty(p))
+        return true
 
-    function isActive(pathname, query, indexOnly=false) {
-      return _isActive(pathname, query, indexOnly, state.location, state.routes, state.params)
-    }
+    return false
+  }
 
-    let partialNextState
+  /**
+   * Returns a new createHistory function that may be used to create
+   * history objects that know about routing.
+   *
+   * - isActive(pathname, query)
+   * - registerRouteHook(route, (location) => {})
+   * - unregisterRouteHook(route, (location) => {})
+   * - match(location, (error, nextState, nextLocation) => {})
+   * - listen((error, nextState) => {})
+   */
+  function useRoutes(createHistory) {
+    return function (options={}) {
+      let { routes, ...historyOptions } = options
+      let history = useQueries(createHistory)(historyOptions)
+      let state = {}
 
-    function match(location, callback) {
-      if (partialNextState && partialNextState.location === location) {
-        // Continue from where we left off.
-        finishMatch(partialNextState, callback)
-      } else {
-        matchRoutes(routes, location, function (error, nextState) {
+      function isActive(pathname, query, indexOnly=false) {
+        return _isActive(pathname, query, indexOnly, state.location, state.routes, state.params)
+      }
+
+      let partialNextState
+
+      function match(location, callback) {
+        if (partialNextState && partialNextState.location === location) {
+          // Continue from where we left off.
+          finishMatch(partialNextState, callback)
+        } else {
+          matchRoutes(routes, location, function (error, nextState) {
+            if (error) {
+              callback(error, null, null)
+            } else if (nextState) {
+              finishMatch({ ...nextState, location }, function (err, nextLocation, nextState) {
+                if (nextState)
+                  state = nextState
+                callback(err, nextLocation, nextState)
+              })
+            } else {
+              callback(null, null, null)
+            }
+          })
+        }
+      }
+
+      function createLocationFromRedirectInfo({ pathname, query, state }) {
+        return createLocation(
+          history.createPath(pathname, query), state, REPLACE, history.createKey()
+        )
+      }
+
+      function finishMatch(nextState, callback) {
+        let { leaveRoutes, enterRoutes } = computeChangedRoutes(state, nextState)
+
+        runLeaveHooks(leaveRoutes)
+
+        runEnterHooks(enterRoutes, nextState, function (error, redirectInfo) {
           if (error) {
-            callback(error, null, null)
-          } else if (nextState) {
-            finishMatch({ ...nextState, location }, function (err, nextLocation, nextState) {
-              if (nextState)
-                state = nextState
-              callback(err, nextLocation, nextState)
-            })
+            callback(error)
+          } else if (redirectInfo) {
+            callback(null, createLocationFromRedirectInfo(redirectInfo), null)
           } else {
-            callback(null, null, null)
+            // TODO: Fetch components after state is updated.
+            getComponents(nextState, function (error, components) {
+              if (error) {
+                callback(error)
+              } else {
+                callback(null, null, { ...nextState, components })
+              }
+            })
           }
         })
       }
-    }
 
-    function createLocationFromRedirectInfo({ pathname, query, state }) {
-      return createLocation(
-        history.createPath(pathname, query), state, REPLACE, history.createKey()
-      )
-    }
+      const RouteHooks = {}
 
-    function finishMatch(nextState, callback) {
-      let { leaveRoutes, enterRoutes } = computeChangedRoutes(state, nextState)
+      let RouteGuid = 1
 
-      runLeaveHooks(leaveRoutes)
-
-      runEnterHooks(enterRoutes, nextState, function (error, redirectInfo) {
-        if (error) {
-          callback(error)
-        } else if (redirectInfo) {
-          callback(null, createLocationFromRedirectInfo(redirectInfo), null)
-        } else {
-          // TODO: Fetch components after state is updated.
-          getComponents(nextState, function (error, components) {
-            if (error) {
-              callback(error)
-            } else {
-              callback(null, null, { ...nextState, components })
-            }
-          })
-        }
-      })
-    }
-
-    const RouteHooks = {}
-
-    let RouteGuid = 1
-
-    function getRouteID(route) {
-      return route.__id__ || (route.__id__ = RouteGuid++)
-    }
-
-    function getRouteHooksForRoutes(routes) {
-      return routes.reduce(function (hooks, route) {
-        hooks.push.apply(hooks, RouteHooks[getRouteID(route)])
-        return hooks
-      }, [])
-    }
-
-    function transitionHook(location, callback) {
-      matchRoutes(routes, location, function (error, nextState) {
-        if (nextState == null) {
-          // TODO: We didn't actually match anything, but hang
-          // onto error/nextState so we don't have to matchRoutes
-          // again in the listen callback.
-          callback()
-          return
-        }
-
-        // Cache some state here so we don't have to
-        // matchRoutes() again in the listen callback.
-        partialNextState = { ...nextState, location }
-
-        let hooks = getRouteHooksForRoutes(
-          computeChangedRoutes(state, nextState).leaveRoutes
-        )
-
-        let result
-        for (let i = 0, len = hooks.length; result == null && i < len; ++i) {
-          // Passing the location arg here indicates to
-          // the user that this is a transition hook.
-          result = hooks[i](location)
-        }
-
-        callback(result)
-      })
-    }
-
-    function beforeUnloadHook() {
-      // Synchronously check to see if any route hooks want to
-      // prevent the current window/tab from closing.
-      if (state.routes) {
-        let hooks = getRouteHooksForRoutes(state.routes)
-
-        let message
-        for (let i = 0, len = hooks.length; typeof message !== 'string' && i < len; ++i) {
-          // Passing no args indicates to the user that this is a
-          // beforeunload hook. We don't know the next location.
-          message = hooks[i]()
-        }
-
-        return message
+      function getRouteID(route) {
+        return route.__id__ || (route.__id__ = RouteGuid++)
       }
-    }
 
-    function registerRouteHook(route, hook) {
-      // TODO: Warn if they register for a route that isn't currently
-      // active. They're probably doing something wrong, like re-creating
-      // route objects on every location change.
-      let routeID = getRouteID(route)
-      let hooks = RouteHooks[routeID]
-
-      if (hooks == null) {
-        let thereWereNoRouteHooks = !hasAnyProperties(RouteHooks)
-
-        hooks = RouteHooks[routeID] = [ hook ]
-
-        if (thereWereNoRouteHooks) {
-          history.registerTransitionHook(transitionHook)
-
-          if (history.registerBeforeUnloadHook)
-            history.registerBeforeUnloadHook(beforeUnloadHook)
-        }
-      } else if (hooks.indexOf(hook) === -1) {
-        hooks.push(hook)
+      function getRouteHooksForRoutes(routes) {
+        return routes.reduce(function (hooks, route) {
+          hooks.push.apply(hooks, RouteHooks[getRouteID(route)])
+          return hooks
+        }, [])
       }
-    }
 
-    function unregisterRouteHook(route, hook) {
-      let routeID = getRouteID(route)
-      let hooks = RouteHooks[routeID]
-
-      if (hooks != null) {
-        let newHooks = hooks.filter(item => item !== hook)
-
-        if (newHooks.length === 0) {
-          delete RouteHooks[routeID]
-
-          if (!hasAnyProperties(RouteHooks)) {
-            history.unregisterTransitionHook(transitionHook)
-
-            if (history.unregisterBeforeUnloadHook)
-              history.unregisterBeforeUnloadHook(beforeUnloadHook)
+      function transitionHook(location, callback) {
+        matchRoutes(routes, location, function (error, nextState) {
+          if (nextState == null) {
+            // TODO: We didn't actually match anything, but hang
+            // onto error/nextState so we don't have to matchRoutes
+            // again in the listen callback.
+            callback()
+            return
           }
-        } else {
-          RouteHooks[routeID] = newHooks
+
+          // Cache some state here so we don't have to
+          // matchRoutes() again in the listen callback.
+          partialNextState = { ...nextState, location }
+
+          let hooks = getRouteHooksForRoutes(
+            computeChangedRoutes(state, nextState).leaveRoutes
+          )
+
+          let result
+          for (let i = 0, len = hooks.length; result == null && i < len; ++i) {
+            // Passing the location arg here indicates to
+            // the user that this is a transition hook.
+            result = hooks[i](location)
+          }
+
+          callback(result)
+        })
+      }
+
+      function beforeUnloadHook() {
+        // Synchronously check to see if any route hooks want to
+        // prevent the current window/tab from closing.
+        if (state.routes) {
+          let hooks = getRouteHooksForRoutes(state.routes)
+
+          let message
+          for (let i = 0, len = hooks.length; typeof message !== 'string' && i < len; ++i) {
+            // Passing no args indicates to the user that this is a
+            // beforeunload hook. We don't know the next location.
+            message = hooks[i]()
+          }
+
+          return message
         }
       }
-    }
 
-    /**
-     * This is the API for stateful environments. As the location changes,
-     * we update state and call the listener. Benefits of this API are:
-     *
-     * - We automatically manage state on the client
-     * - We automatically handle redirects on the client
-     * - We warn when the location doesn't match any routes
-     */
-    function listen(listener) {
-      return history.listen(function (location) {
-        if (state.location === location) {
-          listener(null, state)
-        } else {
-          match(location, function (error, nextLocation, nextState) {
-            if (error) {
-              listener(error)
-            } else if (nextState) {
-              listener(null, state) // match mutates state to nextState
-            } else if (nextLocation) {
-              history.transitionTo(nextLocation)
-            } else {
-              warning(
-                false,
-                'Location "%s" did not match any routes',
-                location.pathname + location.search
-              )
-            }
-          })
+      function registerRouteHook(route, hook) {
+        // TODO: Warn if they register for a route that isn't currently
+        // active. They're probably doing something wrong, like re-creating
+        // route objects on every location change.
+        let routeID = getRouteID(route)
+        let hooks = RouteHooks[routeID]
+
+        if (hooks == null) {
+          let thereWereNoRouteHooks = !hasAnyProperties(RouteHooks)
+
+          hooks = RouteHooks[routeID] = [ hook ]
+
+          if (thereWereNoRouteHooks) {
+            history.registerTransitionHook(transitionHook)
+
+            if (history.registerBeforeUnloadHook)
+              history.registerBeforeUnloadHook(beforeUnloadHook)
+          }
+        } else if (hooks.indexOf(hook) === -1) {
+          hooks.push(hook)
         }
-      })
-    }
+      }
 
-    return {
-      ...history,
-      isActive,
-      registerRouteHook,
-      unregisterRouteHook,
-      listen,
-      match
+      function unregisterRouteHook(route, hook) {
+        let routeID = getRouteID(route)
+        let hooks = RouteHooks[routeID]
+
+        if (hooks != null) {
+          let newHooks = hooks.filter(item => item !== hook)
+
+          if (newHooks.length === 0) {
+            delete RouteHooks[routeID]
+
+            if (!hasAnyProperties(RouteHooks)) {
+              history.unregisterTransitionHook(transitionHook)
+
+              if (history.unregisterBeforeUnloadHook)
+                history.unregisterBeforeUnloadHook(beforeUnloadHook)
+            }
+          } else {
+            RouteHooks[routeID] = newHooks
+          }
+        }
+      }
+
+      /**
+       * This is the API for stateful environments. As the location changes,
+       * we update state and call the listener. Benefits of this API are:
+       *
+       * - We automatically manage state on the client
+       * - We automatically handle redirects on the client
+       * - We warn when the location doesn't match any routes
+       */
+      function listen(listener) {
+        return history.listen(function (location) {
+          if (state.location === location) {
+            listener(null, state)
+          } else {
+            match(location, function (error, nextLocation, nextState) {
+              if (error) {
+                listener(error)
+              } else if (nextState) {
+                listener(null, state) // match mutates state to nextState
+              } else if (nextLocation) {
+                history.transitionTo(nextLocation)
+              } else {
+                warning(
+                  false,
+                  'Location "%s" did not match any routes',
+                  location.pathname + location.search
+                )
+              }
+            })
+          }
+        })
+      }
+
+      return {
+        ...history,
+        isActive,
+        registerRouteHook,
+        unregisterRouteHook,
+        listen,
+        match
+      }
     }
   }
-}
 
-export default useRoutes
+  return useRoutes
+
+}

--- a/native.js
+++ b/native.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/native');


### PR DESCRIPTION
Allows use with React Native or other custom React version.  I followed the same pattern as rackt/react-redux.

The only breaking change with this (since all tests pass, and you guys write awesome tests) would be for people who import directly from "react-router/lib/[something]" and use private APIs. I'm not sure what your thoughts would be on what to do about those people.

I'm also aware that you might not even want to accept a PR like this, given the fact that one day (though none of us know what day that is haha) we can all depend on React >= 0.14, and react-router can depend on just react (sans react-dom), and that will (hopefully) _just work_ with react-native with no changes needed. Ahhh, the future. It will be so nice.

But for using react-router on RN today, this is needed.