### PR TITLE
Upgrade guide

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -41,7 +41,7 @@ React.render(<Router routes={routes}/>, el)
 ### Locations
 
 Locations are now called histories (that emit locations). You import
-them from the `history` package, not react router.
+them from the [`history` package](https://github.com/rackt/history), not react router.
 
 ```js
 // v0.13.x
@@ -74,7 +74,7 @@ Named routes are gone (for now, [see discussion](https://github.com/rackt/react-
 
 Not found really confused people, mistaking not finding resources
 from your API for not matching a route. We've removed it completely
-since its simple with a `*` path.
+since it's simple with a `*` path.
 
 ```js
 // v0.13.x
@@ -87,7 +87,7 @@ since its simple with a `*` path.
 ### Redirect route
 
 - no more params
-- must have absolute "from" (for now)
+- must have absolute `from` (for now)
 
 ```js
 // v0.13.x
@@ -131,11 +131,13 @@ the link will not check if it's active.
 <Link to="/about" activeClassName="active">About</Link>
 ```
 
-#### Linking to Default/Index routes
+#### Linking to Index routes
 
 Because named routes are gone, a link to `/` with an index route at `/`
 will always be active. So we've introduced `IndexLink` that is only
 active when the index route is active.
+
+**Note:** `DefaultRoute` is gone.
 
 ```js
 // v0.13.x


### PR DESCRIPTION
I just went through the process of upgrading from `0.13.x` to `1.0` as per the upgrade guide and made a few changes that should hopefully make things a little easier:
- Added a link to the [`history` package](https://github.com/rackt/history); not everyone will necessarily be familiar with it and there is no harm in being a little more explicit to avoid confusion with any other package that deals with history
- It wasn't clear that `DefaultRoute` was gone, so I explicitly added a note - this is in line with saying explicitly that `RouteHandler` is gone in the following section
- Fixed a really minor grammatical error - it just caught my attention, I couldn't help myself!

Let me know what you think, hopefully these are helpful changes for everyone and not just myself - feedback/suggestions welcome of course :)