### PR TITLE
Update UPGRADE_GUIDE.md

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -55,9 +55,9 @@ let history = createBrowserHistory()
 React.render(<Router history={history}>{routes}</Router>, el)
 ```
 
-After updating to 1.0.0 you will notice that a magic querystring entry starts appearing in your URLs called "_k". An example of how it looks is this: `?_k=umhx1s`.  
+If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a magic querystring entry will start appearing in your URLs called "_k". An example of how it looks is this: `?_k=umhx1s`.  
 
-This is not a bug - this is intended. You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
+This is not a bug - this is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
 
 ### Route Config
 

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -55,9 +55,9 @@ let history = createBrowserHistory()
 React.render(<Router history={history}>{routes}</Router>, el)
 ```
 
-If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a magic querystring entry will start appearing in your URLs called "_k". An example of how it looks is this: `?_k=umhx1s`.  
+If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a querystring entry not defined by yourself will start appearing in your URLs called "_k". An example of how it looks is this: `?_k=umhx1s`.  
 
-This is not a bug - this is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
+This is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
 
 ### Route Config
 


### PR DESCRIPTION
Further tweak to the docs to make clear that the hash based URL "_k" is directly related to hash based histories and doesn't come along for the ride with createBrowserHistory. I realised upon re-reading it that it was a touch confusing at present.