### PR TITLE
Update for history createLocation deprecation

### DIFF
--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -4,13 +4,14 @@ import Route from '../Route'
 
 import assert from 'assert'
 import expect from 'expect'
-import { createLocation } from 'history'
+import { createMemoryHistory } from 'history'
 import { createRoutes } from '../RouteUtils'
 import matchRoutes from '../matchRoutes'
 
 describe('matchRoutes', function () {
 
   let routes, RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute, AboutRoute, TeamRoute, ProfileRoute, CatchAllRoute
+  let createLocation = createMemoryHistory().createLocation
   beforeEach(function () {
     /*
     <Route>

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -2,7 +2,7 @@
 /*eslint react/prop-types: 0*/
 import expect from 'expect'
 import React from 'react'
-import createLocation from 'history/lib/createLocation'
+import createMemoryHistory from 'history/lib/createMemoryHistory'
 import RoutingContext from '../RoutingContext'
 import match from '../match'
 import Link from '../Link'
@@ -71,8 +71,9 @@ describe('server rendering', function () {
   })
 
   it('works', function (done) {
-    const location = createLocation('/dashboard')
-    match({ routes, location }, function (error, redirectLocation, renderProps) {
+    const history = createMemoryHistory()
+    const location = history.createLocation('/dashboard')
+    match({ routes, history, location }, function (error, redirectLocation, renderProps) {
       const string = React.renderToString(
         <RoutingContext {...renderProps} />
       )
@@ -82,8 +83,9 @@ describe('server rendering', function () {
   })
 
   it('renders active Links as active', function (done) {
-    const location = createLocation('/about')
-    match({ routes, location }, function (error, redirectLocation, renderProps) {
+    const history = createMemoryHistory()
+    const location = history.createLocation('/about')
+    match({ routes, history, location }, function (error, redirectLocation, renderProps) {
       const string = React.renderToString(
         <RoutingContext {...renderProps} />
       )
@@ -94,8 +96,9 @@ describe('server rendering', function () {
   })
 
   it('sends the redirect location', function (done) {
-    const location = createLocation('/company')
-    match({ routes, location }, function (error, redirectLocation) {
+    const history = createMemoryHistory()
+    const location = history.createLocation('/company')
+    match({ routes, history, location }, function (error, redirectLocation) {
       expect(redirectLocation).toExist()
       expect(redirectLocation.pathname).toEqual('/about')
       expect(redirectLocation.search).toEqual('')
@@ -106,11 +109,12 @@ describe('server rendering', function () {
   })
 
   it('sends null values when no routes match', function (done) {
-    const location = createLocation('/no-match')
-    match({ routes, location }, function (error, redirectLocation, state) {
-      expect(error).toBe(null)
-      expect(redirectLocation).toBe(null)
-      expect(state).toBe(null)
+    const history = createMemoryHistory()
+    const location = history.createLocation('/no-match')
+    match({ routes, history, location }, function (error, redirectLocation, state) {
+      expect(error).toNotExist()
+      expect(redirectLocation).toNotExist()
+      expect(state).toNotExist()
       done()
     })
   })

--- a/modules/useRoutes.js
+++ b/modules/useRoutes.js
@@ -1,7 +1,6 @@
 import warning from 'warning'
 import { REPLACE } from 'history/lib/Actions'
 import useQueries from 'history/lib/useQueries'
-import createLocation from 'history/lib/createLocation'
 import computeChangedRoutes from './computeChangedRoutes'
 import { runEnterHooks, runLeaveHooks } from './TransitionUtils'
 import { default as _isActive } from './isActive'
@@ -55,7 +54,7 @@ function useRoutes(createHistory) {
     }
 
     function createLocationFromRedirectInfo({ pathname, query, state }) {
-      return createLocation(
+      return history.createLocation(
         history.createPath(pathname, query), state, REPLACE, history.createKey()
       )
     }
@@ -181,7 +180,7 @@ function useRoutes(createHistory) {
       } else if (hooks.indexOf(hook) === -1) {
         hooks.push(hook)
       }
-      
+
       return function () {
         let hooks = RouteHooks[routeID]
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "history": "^1.11.0",
+    "history": "^1.12.0",
     "invariant": "^2.0.0",
     "warning": "^2.0.0"
   },


### PR DESCRIPTION
#2169 was just a docs tweak. This has some real meat. You shouldn't get some upstream deprecation warnings from `history` with this.

The build is still failing on isActive because of be371966. The internal state isn't being populated initially by `useRoutes` when using `match`. I'll see if I can get to that one too.