### PR TITLE
Add state support to match()

### DIFF
--- a/modules/match.js
+++ b/modules/match.js
@@ -18,6 +18,7 @@ const createHistory = useRoutes(useBasename(createMemoryHistory))
 function match({
   routes,
   location,
+  state,
   parseQueryString,
   stringifyQuery,
   basename
@@ -36,7 +37,7 @@ function match({
 
   // Allow match({ location: '/the/path', ... })
   if (typeof location === 'string')
-    location = history.createLocation(location)
+    location = history.createLocation(location, state)
 
   history.match(location, function (error, redirectLocation, nextState) {
     callback(error, redirectLocation, nextState && { ...nextState, history })


### PR DESCRIPTION
This would make it easy to pass state (e.g. `req.body`) without having to duplicate `match()`'s history creation in order to pass a location object in.

```js
match({ routes, location: req.url, state: req.body }, ...
```