### PR TITLE
Update README.md to help new users install v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We support all browsers and environments where React runs.
 
 #### npm + webpack/browserify
 
-    $ npm install react-router
+    $ npm install react-router@1.0.0-rc1
 
 Then with a module bundler or webpack, use as you would anything else:
 


### PR DESCRIPTION
Just installed react-router via the previously given command (which installs v0.13) and spent an hour figuring out why I get errors when just following the tutorial code. Turns out the tutorial code assumes you installed v1. This is really confusing.