### PR TITLE
Ability to open links in new window/tab, using target="_blank"

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -71,6 +71,14 @@ class Link extends React.Component {
     if (clickResult === false || event.defaultPrevented === true)
       allowTransition = false
 
+    // If target prop is set (e.g. to "_blank") let browser handle link.
+    if (this.props.target) {
+      if (!allowTransition)
+        event.preventDefault()
+
+      return
+    }
+
     event.preventDefault()
 
     if (allowTransition)


### PR DESCRIPTION
This pull request adds the ability to open links in new windows or tabs (or frames or browsing contexts in HTML5), using the `target` attribute of the `<a>` tag. Basically, if `target` is set, we let the browser handle the transition itself (similarly to when we middle-click on a link to open it in a new tab).

See #1510 and #2188 for more discussions about this requirement.