### PR TITLE
Revert "Update ServerRendering.md"

### DIFF
--- a/docs/guides/advanced/ServerRendering.md
+++ b/docs/guides/advanced/ServerRendering.md
@@ -16,14 +16,12 @@ It looks something like this with an imaginary JavaScript server:
 ```js
 import { renderToString } from 'react-dom/server'
 import { match, RoutingContext } from 'react-router'
-import createLocation from 'history/lib/createLocation'
 import routes from './routes'
 
 serve((req, res) => {
   // Note that req.url here should be the full URL path from
   // the original request, including the query string.
-  const location = createLocation(req.url);
-  match({ routes, location }, (error, redirectLocation, renderProps) => {
+  match({ routes, location: req.url }, (error, redirectLocation, renderProps) => {
     if (error) {
       res.send(500, error.message)
     } else if (redirectLocation) {


### PR DESCRIPTION
Reverts rackt/react-router#2192

[Using `createLocation` statically is deprecated](https://github.com/rackt/history/commit/21f8dbdeaec458538882f72a4c5a5c2fad2b34da) and this code will generate warnings (and eventually errors) with recent versions of `history`.