### PR TITLE
[added] Ability to specify element tagName prop for Link component

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -43,6 +43,7 @@ class Link extends Component {
   }
 
   static propTypes = {
+    tagName: string,
     to: string.isRequired,
     query: object,
     hash: string,
@@ -54,6 +55,7 @@ class Link extends Component {
   }
 
   static defaultProps = {
+    tagName: 'a',
     onlyActiveOnIndex: false,
     className: '',
     style: {}
@@ -92,7 +94,7 @@ class Link extends Component {
   }
 
   render() {
-    const { to, query, hash, state, activeClassName, activeStyle, onlyActiveOnIndex, ...props } = this.props
+    const { tagName, to, query, hash, state, activeClassName, activeStyle, onlyActiveOnIndex, ...props } = this.props
 
     // Manually override onClick.
     props.onClick = (e) => this.handleClick(e)
@@ -116,7 +118,7 @@ class Link extends Component {
       }
     }
 
-    return <a {...props} />
+    return React.createElement(tagName, props)
   }
 
 }

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -48,6 +48,24 @@ describe('A <Link>', function () {
     })
   })
 
+  it('can be a button', function () {
+    class LinkWrapper extends Component {
+      render() {
+        return <Link tagName="button" type="button" className="link-button" to="/hello/michael">Link</Link>
+      }
+    }
+
+    render((
+      <Router history={createHistory('/')}>
+        <Route path="/" component={LinkWrapper} />
+      </Router>
+    ), node, function () {
+      const button = node.querySelector('.link-button')
+      expect(button.tagName).toEqual('BUTTON')
+      expect(button.type).toEqual('button')
+    })
+  })
+
   // This test needs to be in its own file with beforeEach(resetHash).
   //
   //it('knows how to make its href with HashHistory', function () {


### PR DESCRIPTION
Enables the <Link> component to output arbitrary element tags like <button>.
I wrote a test case, but was unable to install the karma test runner properly so I couldn't verify that the test passes.