### PR TITLE
[added] Peer dependency on history package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ We support all browsers and environments where React runs.
 
 #### npm + webpack/browserify
 
-    $ npm install react-router@1.0.0-rc3
+Install using [npm](https://www.npmjs.com/):
+
+    $ npm install history react-router@latest
+
+Note that you need to also install the [history](https://www.npmjs.com/package/history) package since it is a peer dependency of React Router and won't automatically be installed for you in npm 3+.
 
 Then with a module bundler or webpack, use as you would anything else:
 

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -302,7 +302,7 @@ describe('A <Link>', function () {
         },
         function () {
           expect(node.innerHTML).toMatch(/Hello/)
-          expect(spy).toHaveBeenCalledWith({ you: 'doing?' }, '/hello#world?how=are')
+          expect(spy).toHaveBeenCalledWith({ you: 'doing?' }, { pathname: '/hello', search: '?how=are', hash: '#world' })
         }
       ]
 

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "history": "1.12.3",
     "invariant": "^2.0.0",
     "warning": "^2.0.0"
+  },
+  "peerDependencies": {
+    "history": "~1"
   },
   "devDependencies": {
     "babel": "^5.4.7",
@@ -41,6 +43,7 @@
     "express": "^4.13.3",
     "express-urlrewrite": "^1.2.0",
     "gzip-size": "^3.0.0",
+    "history": "^1.12.5",
     "karma": "^0.13.8",
     "karma-browserstack-launcher": "^0.1.4",
     "karma-chrome-launcher": "^0.2.0",


### PR DESCRIPTION
Since we don't plan on making any breaking changes in the history package without a major version bump, we should be able to just have a peer dep on history `~1`. Please review and merge if it looks good to you, @taion.

Fixes #2211
Fixes #2252