### PR TITLE
Fix getIndexRoute example in DynamicRouting.md

### DIFF
--- a/docs/guides/advanced/DynamicRouting.md
+++ b/docs/guides/advanced/DynamicRouting.md
@@ -30,7 +30,9 @@ const CourseRoute = {
 
   getIndexRoute(location, callback) {
     require.ensure([], function (require) {
-      callback(null, require('./components/Index'))
+      callback(null, {
+        component: require('./components/Index'),
+      })
     })
   },
 


### PR DESCRIPTION
getIndexRoute expects a route, whereas the example was sending a component.