### PR TITLE
[removed] params from RoutingContext child context

### DIFF
--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -26,13 +26,12 @@ class RoutingContext extends Component {
 
   static childContextTypes = {
     history: object.isRequired,
-    location: object.isRequired,
-    params: object.isRequired
+    location: object.isRequired
   }
 
   getChildContext() {
-    const { history, location, params } = this.props
-    return { history, location, params }
+    const { history, location } = this.props
+    return { history, location }
   }
 
   createElement(component, props) {

--- a/modules/__tests__/RouteComponent-test.js
+++ b/modules/__tests__/RouteComponent-test.js
@@ -47,13 +47,11 @@ describe('a Route Component', function () {
     class RouteComponent extends Component {
       static contextTypes = {
         history: object.isRequired,
-        location: object.isRequired,
-        params: object.isRequired
+        location: object.isRequired
       }
       componentDidMount() {
         expect(this.context.history).toEqual(this.props.history)
         expect(this.context.location).toEqual(this.props.location)
-        expect(this.context.params).toEqual(this.props.params)
       }
       render() {
         return null


### PR DESCRIPTION
Per https://github.com/rackt/react-router/pull/2336#commitcomment-13933868.

I'm not entirely comfortable with this - in a vacuum I'd prefer we not have `location` on child context either, but I mostly agree with the point that getting rid of it is not worth making another breaking change.

Might want to consider somehow deprecating it anyway, though.