### PR TITLE
Document confirming navigation with ES6 classes

### DIFF
--- a/docs/guides/advanced/ConfirmingNavigation.md
+++ b/docs/guides/advanced/ConfirmingNavigation.md
@@ -26,6 +26,21 @@ const Home = React.createClass({
 })
 ```
 
+If you are using ES6 classes for your components, you can use [react-mixin](https://github.com/brigand/react-mixin) to add the `Lifecycle` mixin to your component.
+
+```js
+import reactMixin from 'react-mixin'
+import { Lifecycle } from 'react-router'
+
+class Foo extends Component { /* ... */ }
+reactMixin(Foo.prototype, Lifecycle)
+
+// or
+
+@reactMixin.decorate(Lifecycle)
+class Bar extends Component { /* ... */ }
+```
+
 If you need a [`routerWillLeave`](/docs/API.md#routerwillleavenextlocation) hook in a deeply nested component, simply use the [`RouteContext`](/docs/API.md#routecontext-mixin) mixin in your [route component](/docs/Glossary.md#routecomponent) to put the `route` in context.
 
 ```js


### PR DESCRIPTION
Closes #2364 

Here's one way to let users easily use `Lifecycle` when using ES6 classes. Zero LoC change on our end!

I think this is a bit cleaner than implementing on our wrapper - it'd essentially just be duplicating code from a perfectly good library that's already there.