### PR TITLE
[wip][added] Routing middlewares

### DIFF
--- a/modules/Router.js
+++ b/modules/Router.js
@@ -6,7 +6,7 @@ import RoutingContext from './RoutingContext'
 import useRoutes from './useRoutes'
 import { routes } from './PropTypes'
 
-const { func, object } = React.PropTypes
+const { array, func, object } = React.PropTypes
 
 /**
  * A <Router> is a high-level API for automatically setting up
@@ -20,6 +20,7 @@ class Router extends Component {
     children: routes,
     routes, // alias for children
     createElement: func,
+    middlewares: array,
     onError: func,
     onUpdate: func,
     parseQueryString: func,
@@ -79,7 +80,7 @@ class Router extends Component {
 
   render() {
     let { location, routes, params, components } = this.state
-    let { createElement } = this.props
+    let { createElement, middlewares } = this.props
 
     if (location == null)
       return null // Async match
@@ -87,6 +88,7 @@ class Router extends Component {
     return React.createElement(RoutingContext, {
       history: this.history,
       createElement,
+      middlewares,
       location,
       routes,
       params,

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -248,63 +248,78 @@ describe('Router', function () {
 
   })
 
-  it('applies middlewares', function (done) {
-    const Parent = ({ children }) => <span>parent {children}</span>
-    const Child = () => <span>child</span>
+  describe('middlewares', function () {
+    it('applies middlewares', function (done) {
+      const Parent = ({ children }) => <span>parent:{children}</span>
+      const Child = () => <span>child</span>
 
-    class Middleware1 extends Component {
-      createElement = (component, props) => {
-        return (
-          <span>m1-inner {this.props.createElement(component, props)}</span>
-        )
+      class Middleware extends Component {
+        createElement = (component, props) => {
+          return (
+            <span>
+              {this.props.label}-inner:
+              {this.props.createElement(component, props)}
+            </span>
+          )
+        }
+
+        render() {
+          return (
+            <span>
+              {this.props.label}-outer:
+              {React.cloneElement(this.props.children, {
+                createElement: this.createElement
+              })}
+            </span>
+          )
+        }
       }
 
-      render() {
-        return (
-          <span>
-            m1-outer {React.cloneElement(this.props.children, {
-              createElement: this.createElement
-            })}
-          </span>
-        )
-      }
-    }
-
-    class Middleware2 extends Component {
-      createElement = (component, props) => {
-        return (
-          <span>m2-inner {this.props.createElement(component, props)}</span>
-        )
+      function createMiddleware(label) {
+        return <Middleware label={label} />
       }
 
-      render() {
-        return (
-          <span>
-            m2-outer {React.cloneElement(this.props.children, {
-              createElement: this.createElement
-            })}
-          </span>
+      render((
+        <Router
+          history={createHistory('/child')}
+          middlewares={[ createMiddleware('m1'), createMiddleware('m2') ]}
+          >
+          <Route path="/" component={Parent}>
+            <Route path="child" component={Child} />
+          </Route>
+        </Router>
+      ), node, function () {
+        // Note that the nesting order is inverted for `createElement`, because
+        // the order of function application is outermost-first.
+        expect(node.textContent).toBe(
+          'm1-outer:m2-outer:m2-inner:m1-inner:parent:m2-inner:m1-inner:child'
         )
-      }
-    }
-
-    render((
-      <Router
-        history={createHistory('/child')}
-        middlewares={[ <Middleware1 />, <Middleware2 /> ]}
-      >
-        <Route path="/" component={Parent}>
-          <Route path="child" component={Child} />
-        </Route>
-      </Router>
-    ), node, function () {
-      // Note that the nesting order is inverted for `createElement`, because
-      // the order of function application is outermost-first.
-      expect(node.textContent).toEqual(
-        'm1-outer m2-outer m2-inner m1-inner parent m2-inner m1-inner child'
-      )
-      done()
+        done()
+      })
     })
+
+    it('passes router props to middlewares', function (done) {
+      const MyComponent = () => <div />
+      const route = { path: '/', component: MyComponent }
+
+      const Middleware = ({ routes, components, children }) => {
+        expect(routes).toEqual([ route ])
+        expect(components).toEqual([ MyComponent ])
+        done()
+
+        return children
+      }
+      const middleware = <Middleware />
+
+      render((
+        <Router
+          history={createHistory('/')}
+          middlewares={[ middleware ]}
+          routes={route}
+        />
+      ), node)
+    })
+
   })
 
 })


### PR DESCRIPTION
TODO: Add docs if we like this feature

Closes #2088 

I decided to get this out there for visibility before spending time adding explicit docs. The new test case shows this in action, including a bit of an unavoidable quirk.

There's a few things behind this idea:

- `createElement` is not ideal as a point for general customizability because it's not composable - a user doesn't get anything to allow e.g. using both `ReactRouterRelay.createElement` and some other custom `createElement` function
- It's possible to inject additional root components with `createElement`, but it's fairly annoying to do so: https://github.com/relay-tools/react-router-relay/blob/v0.7.0/src/Container.js#L20-L23 (i.e. expose something on child context, and check whether that thing is there - if not, you must be on the root)
- This allows the routing middleware to access more data about the current router state (i.e. both `components` and `routes`), while not forcing us to expose those as props to all route components, which shouldn't need access to all of those (i.e. we could revert the commit fixing https://github.com/rackt/react-router/issues/1788 and remove `routes` from the props injected to route components again)

Let me know what y'all think.