### PR TITLE
[added] Handle undefined query values in isActive

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -537,11 +537,11 @@ Stringifies the query into the pathname, using the router's config.
 Creates a URL, using the router's config. For example, it will add `#/` in front of the `pathname` for hash history.
 
 ##### `isActive(pathname, query, indexOnly)`
-Returns `true` or `false` depending on if the current path is active. Will be true for every route in the route branch matched by the `pathname` (child route is active, therefore parent is too).
+Returns `true` or `false` depending on if the current path is active. Will be true for every route in the route branch matched by the `pathname` (child route is active, therefore parent is too), unless `indexOnly` is specified, in which case it will only match the exact path.
 
 ###### arguments
 - `pathname` - the full URL with or without the query.
-- `query` - an object that will be stringified by the router.
+- `query` - if specified, an object containing key/value pairs that must be active in the current query - explicit `undefined` values require the corresponding key to be missing or `undefined` in the current query
 - `indexOnly` - a boolean (default: `false`).
 
 #### Examples

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -270,5 +270,31 @@ describe('isActive', function () {
         })
       })
     })
+
+    describe('with a query with explicit undefined values', function () {
+      it('matches missing query keys', function (done) {
+        render((
+          <Router history={createHistory('/home?foo=1')}>
+            <Route path="/" />
+            <Route path="/home" />
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/home', { foo: 1, bar: undefined })).toBe(true)
+          done()
+        })
+      })
+
+      it('does not match a present query key', function (done) {
+        render((
+          <Router history={createHistory('/home?foo=1&bar=')}>
+            <Route path="/" />
+            <Route path="/home" />
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/home', { foo: 1, bar: undefined })).toBe(false)
+          done()
+        })
+      })
+    })
   })
 })

--- a/modules/isActive.js
+++ b/modules/isActive.js
@@ -14,9 +14,21 @@ function deepEqual(a, b) {
   }
 
   if (typeof a === 'object') {
-    for (let p in a)
-      if (a.hasOwnProperty(p) && (!b.hasOwnProperty(p) || !deepEqual(a[p], b[p])))
+    for (let p in a) {
+      if (!a.hasOwnProperty(p)) {
+        continue
+      }
+
+      if (a[p] === undefined) {
+        if (b[p] !== undefined) {
+          return false
+        }
+      } else if (!b.hasOwnProperty(p)) {
         return false
+      } else if (!deepEqual(a[p], b[p])) {
+        return false
+      }
+    }
 
     return true
   }


### PR DESCRIPTION
Right now there's no way in `isActive` to require that a given query key is missing in the currently active query.

This makes `null` values on the specified query match absent or otherwise `null`-y values on the active query.