### PR TITLE
[added] Greedy splat (**)

### DIFF
--- a/docs/guides/basics/RouteMatching.md
+++ b/docs/guides/basics/RouteMatching.md
@@ -15,11 +15,13 @@ A route path is [a string pattern](/docs/Glossary.md#routepattern) that is used 
   - `:paramName` – matches a URL segment up to the next `/`, `?`, or `#`. The matched string is called a [param](/docs/Glossary.md#params)
   - `()` – Wraps a portion of the URL that is optional
   - `*` – Matches all characters (non-greedy) up to the next character in the pattern, or to the end of the URL if there is none, and creates a `splat` [param](/docs/Glossary.md#params)
+  - `**` - Matches all characters (greedy) until the next `/`, `?`, or `#` and creates a `splat` [param](/docs/Glossary.md#params)
 
 ```js
 <Route path="/hello/:name">         // matches /hello/michael and /hello/ryan
 <Route path="/hello(/:name)">       // matches /hello, /hello/michael, and /hello/ryan
 <Route path="/files/*.*">           // matches /files/hello.jpg and /files/path/to/hello.jpg
+<Route path="/**/*.jpg">            // matches /files/hello.jpg and /files/path/to/file.jpg
 ```
 
 If a route uses a relative `path`, it builds upon the accumulated `path` of its ancestors. Nested routes may opt-out of this behavior by [using an absolute `path`](RouteConfiguration.md#decoupling-the-ui-from-the-url).

--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -13,7 +13,7 @@ function _compilePattern(pattern) {
   const paramNames = []
   const tokens = []
 
-  let match, lastIndex = 0, matcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|\*|\(|\)/g
+  let match, lastIndex = 0, matcher = /:([a-zA-Z_$][a-zA-Z0-9_$]*)|\*\*|\*|\(|\)/g
   while ((match = matcher.exec(pattern))) {
     if (match.index !== lastIndex) {
       tokens.push(pattern.slice(lastIndex, match.index))
@@ -23,6 +23,9 @@ function _compilePattern(pattern) {
     if (match[1]) {
       regexpSource += '([^/?#]+)'
       paramNames.push(match[1])
+    } else if (match[0] === '**') {
+      regexpSource += '([\\s\\S]*)'
+      paramNames.push('splat')
     } else if (match[0] === '*') {
       regexpSource += '([\\s\\S]*?)'
       paramNames.push('splat')
@@ -141,7 +144,7 @@ export function formatPattern(pattern, params) {
   for (let i = 0, len = tokens.length; i < len; ++i) {
     token = tokens[i]
 
-    if (token === '*') {
+    if (token === '*' || token === '**') {
       paramValue = Array.isArray(params.splat) ? params.splat[splatIndex++] : params.splat
 
       invariant(

--- a/modules/__tests__/PatternUtils-test.js
+++ b/modules/__tests__/PatternUtils-test.js
@@ -10,7 +10,7 @@ describe('matchPattern', function () {
       paramValues
     })
   }
-  
+
   it('works without params', function () {
     assertMatch('/', '/path', 'path', [], [])
   })
@@ -26,6 +26,14 @@ describe('matchPattern', function () {
 
   it('ignores trailing slashes', function () {
     assertMatch('/:id', '/path/', '', [ 'id' ], [ 'path' ])
+  })
+
+  it('works with greedy splat (**)', function () {
+    assertMatch('/**/g', '/greedy/is/good/g', '', [ 'splat' ], [ 'greedy/is/good' ])
+  })
+
+  it('works with greedy and non-greedy splat', function () {
+    assertMatch('/**/*.jpg', '/files/path/to/file.jpg', '', [ 'splat', 'splat' ], [ 'files/path/to', 'file' ])
   })
 
 })

--- a/modules/__tests__/formatPattern-test.js
+++ b/modules/__tests__/formatPattern-test.js
@@ -98,6 +98,19 @@ describe('formatPattern', function () {
     })
   })
 
+  describe('when a pattern has a greedy splat', function () {
+    it('returns the correct path', function () {
+      expect(formatPattern('/a/**/d', { splat: 'b/c/d' })).toEqual('/a/b/c/d/d')
+      expect(formatPattern('/a/**/d/**', { splat: [ 'b/c/d', 'e' ] })).toEqual('/a/b/c/d/d/e')
+    })
+
+    it('complains if not given enough splat values', function () {
+      expect(function () {
+        formatPattern('/a/**/d/**', { splat: [ 'b/c/d' ] })
+      }).toThrow(Error)
+    })
+  })
+
   describe('when a pattern has dots', function () {
     it('returns the correct path', function () {
       expect(formatPattern('/foo.bar.baz')).toEqual('/foo.bar.baz')

--- a/modules/__tests__/getParams-test.js
+++ b/modules/__tests__/getParams-test.js
@@ -131,6 +131,20 @@ describe('getParams', function () {
     })
   })
 
+  describe('when a pattern has a **', function () {
+    describe('and the path matches', function () {
+      it('return an object with the params', function () {
+        expect(getParams('/**/f', '/foo/bar/f')).toEqual({ splat: 'foo/bar' })
+      })
+    })
+
+    describe('and the path does not match', function () {
+      it('returns null', function () {
+        expect(getParams('/**/f', '/foo/bar/')).toBe(null)
+      })
+    })
+  })
+
   describe('when a pattern has an optional group', function () {
     const pattern = '/archive(/:name)'
 

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -7,7 +7,7 @@ import Route from '../Route'
 
 describe('matchRoutes', function () {
 
-  let routes, RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute, AboutRoute, TeamRoute, ProfileRoute, CatchAllRoute
+  let routes, RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute, AboutRoute, TeamRoute, ProfileRoute, GreedyRoute, CatchAllRoute
   let createLocation = createMemoryHistory().createLocation
   beforeEach(function () {
     /*
@@ -54,6 +54,9 @@ describe('matchRoutes', function () {
       AboutRoute = {
         path: '/about'
       },
+      GreedyRoute = {
+        path: '/**/f'
+      },
       CatchAllRoute = {
         path: '*'
       }
@@ -99,6 +102,17 @@ describe('matchRoutes', function () {
           expect(match).toExist()
           expect(match.routes).toEqual([ FilesRoute ])
           expect(match.params).toEqual({ splat: [ 'a', 'b/c' ] })
+          done()
+        })
+      })
+    })
+
+    describe('when the location matches a nested route with a greedy splat param', function () {
+      it('matches the correct routes and params', function (done) {
+        matchRoutes(routes, createLocation('/foo/bar/f'), function (error, match) {
+          expect(match).toExist()
+          expect(match.routes).toEqual([ GreedyRoute ])
+          expect(match.params).toEqual({ splat: 'foo/bar' })
           done()
         })
       })


### PR DESCRIPTION
As discussed #2284, this pull request add support to greedy splat `**`.

Example of matching:
```
/*/c matches /you/are/okay/c
/*/c does not match /you/are/cool/c
/**/c matches /you/are/cool/c
```

Fix #2284 