### PR TITLE
Change file extension in example

### DIFF
--- a/docs/guides/basics/RouteMatching.md
+++ b/docs/guides/basics/RouteMatching.md
@@ -20,7 +20,7 @@ A route path is [a string pattern](/docs/Glossary.md#routepattern) that is used 
 ```js
 <Route path="/hello/:name">         // matches /hello/michael and /hello/ryan
 <Route path="/hello(/:name)">       // matches /hello, /hello/michael, and /hello/ryan
-<Route path="/files/*.*">           // matches /files/hello.jpg and /files/path/to/hello.jpg
+<Route path="/files/*.*">           // matches /files/hello.jpg and /files/hello.html
 <Route path="/**/*.jpg">            // matches /files/hello.jpg and /files/path/to/file.jpg
 ```
 


### PR DESCRIPTION
Changing the file extension in 
```js
<Route path="/files/*.*">           // matches /files/hello.jpg and /files/path/to/hello.jpg
```
to
`// matches /files/hello.jpg and /files/path/to/hello.html`

So we can make it clear that this path takes any file extension. As opposed to the next example that only accepts `jpg`.