### PR TITLE
Add an "Importing" section to the upgrade guide

### DIFF
--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -16,6 +16,24 @@ integration with libs like redux and relay, and lots more.
 
 But for now, here's how to translate the old API to the new one.
 
+### Importing
+
+The new `Router` component is a property of the top-level module.
+
+```js
+// v0.13.x
+var Router = require('react-router');
+var Route = Router.Route;
+
+// v1.0
+var ReactRouter = require('react-router');
+var Router = ReactRouter.Router;
+var Route = ReactRouter.Route;
+
+// or using object destructuring
+var { Router, Route } = require('react-router');
+```
+
 ### Rendering
 
 ```js


### PR DESCRIPTION
I've been bitten by this before and subsequently seen it as a source of questions on Stack Overflow and Reactiflux.

It's especially tricksy because `Router` is commonly used when importing 0.13.x.