### PR TITLE
[fixed] Index routes with extraneous slashes

### DIFF
--- a/modules/PatternUtils.js
+++ b/modules/PatternUtils.js
@@ -92,7 +92,7 @@ export function matchPattern(pattern, pathname) {
 
   let { regexpSource, paramNames, tokens } = compilePattern(pattern)
 
-  regexpSource += '/*' // Ignore trailing slashes
+  regexpSource += '/*' // Capture path separators
 
   // Special-case patterns like '*' for catch-all routes.
   const captureRemaining = tokens[tokens.length - 1] !== '*'
@@ -106,28 +106,27 @@ export function matchPattern(pattern, pathname) {
 
   let remainingPathname, paramValues
   if (match != null) {
-    let matchedPath
     if (captureRemaining) {
       remainingPathname = match.pop()
-      matchedPath =
+      const matchedPath =
         match[0].substr(0, match[0].length - remainingPathname.length)
-    } else {
-      // If this matched at all, then the match was the entire pathname.
-      matchedPath = match[0]
-      remainingPathname = ''
-    }
 
-    // Ensure we actually match at a path boundary.
-    if (remainingPathname && remainingPathname.charAt(0) !== '/') {
-      // This depends on the leading slash getting added to pathname above to
-      // work in all cases.
-      if (!matchedPath || matchedPath.charAt(matchedPath.length - 1) !== '/') {
+      // If we didn't match the entire pathname, then make sure that the match
+      // we did get ends at a path separator (potentially the one we added
+      // above at the beginning of the path, if the actual match was empty).
+      if (
+        remainingPathname &&
+        matchedPath.charAt(matchedPath.length - 1) !== '/'
+      ) {
         return {
           remainingPathname: null,
           paramNames,
           paramValues: null
         }
       }
+    } else {
+      // If this matched at all, then the match was the entire pathname.
+      remainingPathname = ''
     }
 
     paramValues = match.slice(1).map(

--- a/modules/PropTypes.js
+++ b/modules/PropTypes.js
@@ -3,7 +3,6 @@ import { PropTypes } from 'react'
 const { func, object, arrayOf, oneOfType, element, shape, string } = PropTypes
 
 export function falsy(props, propName, componentName) {
-  /* istanbul ignore if: sanity check */
   if (props[propName])
     return new Error(`<${componentName}> should not have a "${propName}" prop`)
 }

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -72,6 +72,70 @@ describe('isActive', function () {
     })
   })
 
+  describe('nested routes', function () {
+    describe('on the child', function () {
+      it('is active for the child and the parent', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child" />
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent/child')).toBe(true)
+          expect(this.history.isActive('/parent/child', null, true)).toBe(true)
+          expect(this.history.isActive('/parent')).toBe(true)
+          expect(this.history.isActive('/parent', null, true)).toBe(false)
+          done()
+        })
+      })
+
+      it('is active with extraneous slashes', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child" />
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent////child////')).toBe(true)
+          done()
+        })
+      })
+
+      it('is not active with missing slashes', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child" />
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parentchild')).toBe(false)
+          done()
+        })
+      })
+    })
+
+    describe('on the parent', function () {
+      it('is active for the parent', function (done) {
+        render((
+          <Router history={createHistory('/parent')}>
+            <Route path="/parent">
+              <Route path="child" />
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent/child')).toBe(false)
+          expect(this.history.isActive('/parent/child', null, true)).toBe(false)
+          expect(this.history.isActive('/parent')).toBe(true)
+          expect(this.history.isActive('/parent', null, true)).toBe(true)
+          done()
+        })
+      })
+    })
+  })
+
   describe('a pathname that matches a parent route, but not the URL directly', function () {
     describe('with no query', function () {
       it('is active', function (done) {
@@ -184,6 +248,96 @@ describe('isActive', function () {
         ), node, function () {
           expect(this.history.isActive('/home', { something: 'else' })).toBe(false)
           expect(this.history.isActive('/home', { something: 'else' }, true)).toBe(false)
+          done()
+        })
+      })
+    })
+
+    describe('with the index route nested under a pathless route', function () {
+      it('is active', function (done) {
+        render((
+          <Router history={createHistory('/home')}>
+            <Route path="/home">
+              <Route>
+                <IndexRoute />
+              </Route>
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/home', null)).toBe(true)
+          expect(this.history.isActive('/home', null, true)).toBe(true)
+          done()
+        })
+      })
+    })
+
+    describe('with a nested index route', function () {
+      it('is active', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child">
+                <IndexRoute />
+              </Route>
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent/child', null)).toBe(true)
+          expect(this.history.isActive('/parent/child', null, true)).toBe(true)
+          done()
+        })
+      })
+
+      it('is active with extraneous slashes', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child">
+                <IndexRoute />
+              </Route>
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent///child///', null)).toBe(true)
+          expect(this.history.isActive('/parent///child///', null, true)).toBe(true)
+          done()
+        })
+      })
+    })
+
+    describe('with a nested index route under a pathless route', function () {
+      it('is active', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child">
+                <Route>
+                  <IndexRoute />
+                </Route>
+              </Route>
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent/child', null)).toBe(true)
+          expect(this.history.isActive('/parent/child', null, true)).toBe(true)
+          done()
+        })
+      })
+
+      it('is active with extraneous slashes', function (done) {
+        render((
+          <Router history={createHistory('/parent/child')}>
+            <Route path="/parent">
+              <Route path="child">
+                <Route>
+                  <IndexRoute />
+                </Route>
+              </Route>
+            </Route>
+          </Router>
+        ), node, function () {
+          expect(this.history.isActive('/parent///child///', null)).toBe(true)
+          expect(this.history.isActive('/parent///child///', null, true)).toBe(true)
           done()
         })
       })

--- a/modules/__tests__/matchRoutes-test.js
+++ b/modules/__tests__/matchRoutes-test.js
@@ -4,9 +4,9 @@ import { createMemoryHistory } from 'history'
 import { createRoutes } from '../RouteUtils'
 import matchRoutes from '../matchRoutes'
 import Route from '../Route'
+import IndexRoute from '../IndexRoute'
 
 describe('matchRoutes', function () {
-
   let routes
   let
     RootRoute, UsersRoute, UsersIndexRoute, UserRoute, PostRoute, FilesRoute,
@@ -331,4 +331,33 @@ describe('matchRoutes', function () {
     })
   })
 
+  describe('invalid route configs', function () {
+    let invalidRoutes, errorSpy
+
+    beforeEach(function () {
+      errorSpy = expect.spyOn(console, 'error')
+    })
+
+    afterEach(function () {
+      errorSpy.restore()
+    })
+
+    describe('index route with path', function () {
+      beforeEach(function () {
+        invalidRoutes = createRoutes(
+          <Route path="/">
+            <IndexRoute path="foo" />
+          </Route>
+        )
+      })
+
+      it('complains when matching', function (done) {
+        matchRoutes(invalidRoutes, createLocation('/'), function (error, match) {
+          expect(match).toExist()
+          expect(errorSpy).toHaveBeenCalledWith('Warning: Index routes should not have paths')
+          done()
+        })
+      })
+    })
+  })
 })

--- a/modules/matchRoutes.js
+++ b/modules/matchRoutes.js
@@ -1,3 +1,4 @@
+import warning from 'warning'
 import { loopAsync } from './AsyncUtils'
 import { matchPattern } from './PatternUtils'
 import { createRoutes } from './RouteUtils'
@@ -90,10 +91,19 @@ function matchRouteDeep(
         if (error) {
           callback(error)
         } else {
-          if (Array.isArray(indexRoute))
+          if (Array.isArray(indexRoute)) {
+            warning(
+              indexRoute.every(route => !route.path),
+              'Index routes should not have paths'
+            )
             match.routes.push(...indexRoute)
-          else if (indexRoute)
+          } else if (indexRoute) {
+            warning(
+              !indexRoute.path,
+              'Index routes should not have paths'
+            )
             match.routes.push(indexRoute)
+          }
 
           callback(null, match)
         }


### PR DESCRIPTION
This fixes the behavior referenced https://github.com/rackt/react-router/pull/2421#issuecomment-152698992, per https://github.com/rackt/react-router/pull/2425#issuecomment-152625621.

I add the check in `matchRoutes` to ensure that index routes actually don't have paths set (since you might not hit the prop type check if you're using plain route objects).

I've also added a couple of extra test cases to cover more routing and matching.

@mjackson Can you take a look when you have a chance? If we don't want to ignore extraneous slashes between path elements (analogous to what we do at the end of a path), then the previous implementation of "active on index" is probably better.