### PR TITLE
[removed] Remove deprecated handler prop on Route

### DIFF
--- a/modules/Route.js
+++ b/modules/Route.js
@@ -1,4 +1,3 @@
-import warning from 'warning'
 import invariant from 'invariant'
 import React, { Component } from 'react'
 import { createRouteFromReactElement } from './RouteUtils'
@@ -18,27 +17,11 @@ const { string, bool, func } = React.PropTypes
  */
 class Route extends Component {
 
-  static createRouteFromReactElement(element) {
-    const route = createRouteFromReactElement(element)
-
-    /* istanbul ignore if: deprecation */
-    if (route.handler) {
-      warning(
-        false,
-        '<Route handler> is deprecated, use <Route component> instead'
-      )
-
-      route.component = route.handler
-      delete route.handler
-    }
-
-    return route
-  }
+  static createRouteFromReactElement = createRouteFromReactElement
 
   static propTypes = {
     path: string,
     ignoreScrollBehavior: bool,
-    handler: component, // deprecated
     component,
     components,
     getComponents: func


### PR DESCRIPTION
Fixes https://github.com/rackt/react-router/issues/2438

Unless I'm missing some reason that we need to keep this around. This is out last chance to delete it before semver means we can't do so without cutting a 2.x.