### PR TITLE
[fixed] Docs for named/multiple components

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -434,7 +434,7 @@ class App extends React.Component {
 ```
 
 ### Named Components
-When a route has multiple components, the child elements are available by name on `this.props.children`. All route components can participate in the nesting.
+When a route has multiple components, the child elements are available by name on `this.props`. All route components can participate in the nesting.
 
 #### Example
 ```js
@@ -456,11 +456,11 @@ class App extends React.Component {
       <div>
         <div className="Main">
           {/* this will either be <Groups> or <Users> */}
-          {this.props.children.main}
+          {this.props.main}
         </div>
         <div className="Sidebar">
           {/* this will either be <GroupsSidebar> or <UsersSidebar> */}
-          {this.props.children.sidebar}
+          {this.props.sidebar}
         </div>
       </div>
     )

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,8 +14,7 @@
   - [IndexRedirect](#indexredirect)
 
 * [Handler Components](#handler-components)
-
-* [Named Components](#named-components)
+  - [Named Components](#named-components)
 
 * [Mixins](#mixins)
   - [Lifecycle](#lifecycle-mixin)
@@ -182,6 +181,10 @@ pairs to be rendered when the path matches the URL. They can be rendered
 by the parent route component with `this.props[name]`.
 
 ```js
+// Think of it outside the context of the router - if you had pluggable
+// portions of your `render`, you might do it like this:
+// <App main={<Users />} sidebar={<UsersSidebar />} />
+
 const routes = (
   <Route component={App}>
     <Route path="groups" components={{main: Groups, sidebar: GroupsSidebar}}/>
@@ -469,8 +472,8 @@ class Users extends React.Component {
     return (
       <div>
         {/* if at "/users/123" this will be <Profile> */}
-        {/* UsersSidebar will also get <Profile> as this.props.children
-            you pick where it renders */}
+        {/* UsersSidebar will also get <Profile> as this.props.children.
+            You can pick where it renders */}
         {this.props.children}
       </div>
     )

--- a/docs/API.md
+++ b/docs/API.md
@@ -175,16 +175,11 @@ class App extends React.Component {
 ```
 
 ##### `components`
-Routes can define multiple components as an object of `name:component`
+Routes can define one or more named components as an object of `name:component`
 pairs to be rendered when the path matches the URL. They can be rendered
-by the parent route component with `this.props.children[name]`.
+by the parent route component with `this.props[name]`.
 
 ```js
-// think of it outside the context of the router, if you had pluggable
-// portions of your `render`, you might do it like this
-<App children={{main: <Users/>, sidebar: <UsersSidebar/>}}/>
-
-// So with the router it looks like this:
 const routes = (
   <Route component={App}>
     <Route path="groups" components={{main: Groups, sidebar: GroupsSidebar}}/>
@@ -196,7 +191,7 @@ const routes = (
 
 class App extends React.Component {
   render () {
-    const { main, sidebar } = this.props.children
+    const { main, sidebar } = this.props
     return (
       <div>
         <div className="Main">
@@ -432,55 +427,6 @@ class App extends React.Component {
   }
 }
 ```
-
-### Named Components
-When a route has multiple components, the child elements are available by name on `this.props`. All route components can participate in the nesting.
-
-#### Example
-```js
-render((
-  <Router>
-    <Route path="/" component={App}>
-      <Route path="groups" components={{main: Groups, sidebar: GroupsSidebar}} />
-      <Route path="users" components={{main: Users, sidebar: UsersSidebar}}>
-        <Route path="users/:userId" component={Profile} />
-      </Route>
-    </Route>
-  </Router>
-), node)
-
-class App extends React.Component {
-  render() {
-    // the matched child route components become props in the parent
-    return (
-      <div>
-        <div className="Main">
-          {/* this will either be <Groups> or <Users> */}
-          {this.props.main}
-        </div>
-        <div className="Sidebar">
-          {/* this will either be <GroupsSidebar> or <UsersSidebar> */}
-          {this.props.sidebar}
-        </div>
-      </div>
-    )
-  }
-}
-
-class Users extends React.Component {
-  render() {
-    return (
-      <div>
-        {/* if at "/users/123" this will be <Profile> */}
-        {/* UsersSidebar will also get <Profile> as this.props.children,
-            you pick where it renders */}
-        {this.props.children}
-      </div>
-    )
-  }
-}
-```
-
 
 
 ## Mixins

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,8 @@
 
 * [Handler Components](#handler-components)
 
+* [Named Components](#named-components)
+
 * [Mixins](#mixins)
   - [Lifecycle](#lifecycle-mixin)
   - [History](#history-mixin)
@@ -403,7 +405,7 @@ The route that rendered this component.
 A subset of `this.props.params` that were directly specified in this component's route. For example, if the route's path is `users/:userId` and the URL is `/users/123/portfolios/345` then `this.props.routeParams` will be `{userId: '123'}`, and `this.props.params` will be `{userId: '123', portfolioId: 345}`.
 
 #### `children`
-The matched child route elements to be rendered.
+The matched child route element to be rendered. If the route has [named components](https://github.com/rackt/react-router/blob/master/docs/API.md#named-components) then this will be undefined, and the components will instead be available as direct properties on `this.props`.
 
 ##### Example
 ```js
@@ -421,6 +423,54 @@ class App extends React.Component {
     return (
       <div>
         {/* this will be either <Users> or <Groups> */}
+        {this.props.children}
+      </div>
+    )
+  }
+}
+```
+
+### Named Components
+When a route has one or more named components, the child elements are available by name on `this.props`. In this case `this.props.children` will be undefined. All route components can participate in the nesting.
+
+#### Example
+```js
+render((
+  <Router>
+    <Route path="/" component={App}>
+      <Route path="groups" components={{main: Groups, sidebar: GroupsSidebar}} />
+      <Route path="users" components={{main: Users, sidebar: UsersSidebar}}>
+        <Route path="users/:userId" component={Profile} />
+      </Route>
+    </Route>
+  </Router>
+), node)
+
+class App extends React.Component {
+  render() {
+    // the matched child route components become props in the parent
+    return (
+      <div>
+        <div className="Main">
+          {/* this will either be <Groups> or <Users> */}
+          {this.props.main}
+        </div>
+        <div className="Sidebar">
+          {/* this will either be <GroupsSidebar> or <UsersSidebar> */}
+          {this.props.sidebar}
+        </div>
+      </div>
+    )
+  }
+}
+
+class Users extends React.Component {
+  render() {
+    return (
+      <div>
+        {/* if at "/users/123" this will be <Profile> */}
+        {/* UsersSidebar will also get <Profile> as this.props.children
+            you pick where it renders */}
         {this.props.children}
       </div>
     )


### PR DESCRIPTION
When using named/multiple components in a route definition, they are now available as this.props[name] not this.props.children[name]. This PR updates the docs to match the [example](https://github.com/rackt/react-router/blob/master/examples/sidebar/app.js) and the [test coverage](https://github.com/rackt/react-router/blob/master/modules/__tests__/Router-test.js#L108). This also drops the duplicate named component paragraph, which is superfluous.