### PR TITLE
Use whitelist instead of blacklist for packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-examples
-scripts
-__tests__
-karma.conf.js
-tests.webpack.js
-webpack.config.js

--- a/package.json
+++ b/package.json
@@ -2,6 +2,13 @@
   "name": "react-router",
   "version": "1.0.0-rc4",
   "description": "A complete routing library for React.js",
+  "files": [
+    "*.md",
+    "docs",
+    "lib",
+    "npm-scripts",
+    "umd"
+  ],
   "main": "lib/index",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We currently have a bunch of random stuff like `coverage/` and `.travis.yml` in our distributed tarball. IMO it's easier to keep track of things when whitelisting rather than blacklisting from `package.json`, and easier to tell what we're doing.

This does drop `modules/` from the tarball, though - I do feel that it's pretty standard to exclude the pre-transpiled ES6 sources from most builds (React does this, for example), but - Chesterton's fence and all.