### PR TITLE
Pass route state to onUpdate callback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,20 @@
 ## [HEAD]
 
+## [v1.1.0]
 
+### Router `onUpdate` prop
+
+Functions passed as the `onUpdate` prop to a `<Router />` component will be invoked with the new router state as the first argument. For example:
+
+```js
+function handleUpdate (state) {
+  console.log(state) // { components, location, params, routes }
+}
+
+ReactDOM.render(<Router onUpdate={ handleUpdate }>...</Router>, el)
+```
+
+As before this change, `onUpdate` is called within the scope of the router. So it is still possible to access router state using `this.state`.
 
 ## [v1.0.0]
 
@@ -313,7 +327,7 @@ For example, `params` is not available via context.
 We're developing scroll behaviors separately in the
 [`scroll-behavior`](https://github.com/rackt/scroll-behavior)
 library until we have a stable, robust implementation that we're happy with.
-Currently, scroll behaviors are exposed there as history enhancers: 
+Currently, scroll behaviors are exposed there as history enhancers:
 
 ```js
 import createHistory from 'history/lib/createBrowserHistory'
@@ -350,5 +364,3 @@ To cancel a "transition from", please refer to the
 
 There's a lot of the old API we've missed, please give the [new
 docs](/docs) a read and help us fill this guide in. Thanks!
-
-

--- a/docs/API.md
+++ b/docs/API.md
@@ -71,8 +71,8 @@ A function used to convert a query string into an object that gets passed to rou
 ##### `onError(error)`
 While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentscallback), [`route.getIndexRoute`](#getindexroutecallback), and [`route.getChildRoutes`](#getchildrouteslocation-callback).
 
-##### `onUpdate()`
-Called whenever the router updates its state in response to URL changes.
+##### `onUpdate(routerState)`
+Called whenever the router updates its state in response to URL changes. This new state is passed as the first argument.
 
 #### Examples
 Please see the [`examples/`](/examples) directory of the repository for extensive examples of using `Router`.

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -52,7 +52,7 @@ class Router extends Component {
   }
 
   componentWillMount() {
-    let { history, children, routes, parseQueryString, stringifyQuery } = this.props
+    let { history, children, routes, onUpdate, parseQueryString, stringifyQuery } = this.props
     let createHistory = history ? () => history : createHashHistory
 
     this.history = useRoutes(createHistory)({
@@ -65,7 +65,7 @@ class Router extends Component {
       if (error) {
         this.handleError(error)
       } else {
-        this.setState(state, this.props.onUpdate)
+        this.setState(state, () => onUpdate && onUpdate.call(this, state))
       }
     })
   }

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -425,4 +425,21 @@ describe('Router', function () {
       }).toThrow('error fixture')
     })
   })
+
+  describe('onUpdate', function () {
+    it('should pass the router state as the first argument', function (done) {
+
+      function onUpdate(state) {
+        expect(state).toEqual(this.state)
+        done()
+      }
+
+      render((
+        <Router history={createHistory('/')} onUpdate={onUpdate}>
+          <Route path="/" component={Child} />
+        </Router>
+      ), node)
+    })
+
+  })
 })


### PR DESCRIPTION
I'd really love for the route state to be passed into the `onUpdate` callback `<Router />` prop. In particular, I'm working on some ReactRouter based integration for another project and found maintaining the scope of `onUpdate` in the callback to be troublesome.

This is a follow up to https://github.com/rackt/react-router/issues/1539. Things got a little quiet there so I thought I'd just send a PR to get the conversation going again.

Really, I suppose it's more a shame that state isn't provided to the callback inside of `ReactComponent::setState`. But here we are :smile:.

Also: awesome work on the 1.0 API. This is really top notch.