### PR TITLE
Use decodeURIComponent for window.location.search

### DIFF
--- a/modules/locations/HistoryLocation.js
+++ b/modules/locations/HistoryLocation.js
@@ -71,9 +71,7 @@ var HistoryLocation = {
   pop: History.back,
 
   getCurrentPath() {
-    return decodeURI(
-      window.location.pathname + window.location.search
-    );
+    return decodeURI(window.location.pathname) + decodeURIComponent(window.location.search);
   },
 
   toString() {


### PR DESCRIPTION
decodeURI does not decode certain characters (&,@ etc) so query strings involving these characters are returned partially decoded