### PR TITLE
Add back housekeeping updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
+sudo: false
+
 language: node_js
 node_js:
-  - "4"
-sudo: false
+  - stable
+
+cache:
+  directories:
+    - node_modules
+
 before_script:
   - wget http://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip
   - unzip BrowserStackLocal-linux-x64.zip
   - "./BrowserStackLocal $BROWSER_STACK_ACCESS_KEY localhost,8001,0 > /dev/null &"
   - sleep 10
+
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/codecov.io/bin/codecov.io.js
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+
 branches:
-  except:
-  - latest
-  - "/^v\\d/"
+  only:
+    - master

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,131 +1,154 @@
-var webpack = require('webpack')
 var path = require('path')
+var webpack = require('webpack')
+
+// Browsers to run on BrowserStack.
+var CUSTOM_LAUNCHERS = {
+  BS_Chrome: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '8.1',
+    browser: 'chrome',
+    browser_version: '39.0'
+  },
+  BS_Firefox: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '8.1',
+    browser: 'firefox',
+    browser_version: '32.0'
+  },
+  BS_Safari: {
+    base: 'BrowserStack',
+    os: 'OS X',
+    os_version: 'Yosemite',
+    browser: 'safari',
+    browser_version: '8.0'
+  },
+  BS_MobileSafari: {
+    base: 'BrowserStack',
+    os: 'ios',
+    os_version: '7.0',
+    browser: 'iphone',
+    real_mobile: false
+  },
+//  BS_InternetExplorer9: {
+//    base: 'BrowserStack',
+//    os: 'Windows',
+//    os_version: '7',
+//    browser: 'ie',
+//    browser_version: '9.0'
+//  },
+  BS_InternetExplorer10: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '8',
+    browser: 'ie',
+    browser_version: '10.0'
+  },
+  BS_InternetExplorer11: {
+    base: 'BrowserStack',
+    os: 'Windows',
+    os_version: '8.1',
+    browser: 'ie',
+    browser_version: '11.0'
+  }
+}
+
+function setBrowserStack(config, project) {
+  const env = process.env
+
+  if (env.USE_CLOUD) {
+    config.set({
+      customLaunchers: CUSTOM_LAUNCHERS,
+      browsers: Object.keys(CUSTOM_LAUNCHERS),
+      reporters: [ 'dots', 'coverage' ],
+      browserDisconnectTimeout: 10000,
+      browserDisconnectTolerance: 3,
+      browserNoActivityTimeout: 30000,
+      captureTimeout: 120000,
+      browserStack: {
+        username: env.BROWSER_STACK_USERNAME,
+        accessKey: env.BROWSER_STACK_ACCESS_KEY,
+        pollingTimeout: 10000,
+        startTunnel: true
+      }
+    })
+
+    config.reporters[0]  = 'dots'
+
+    if (env.TRAVIS) {
+      var buildLabel = 'TRAVIS #' + env.TRAVIS_BUILD_NUMBER + ' (' + env.TRAVIS_BUILD_ID + ')'
+
+      Object.assign(config.browserStack, {
+        startTunnel: false,
+        project: project,
+        build: buildLabel,
+        name: env.TRAVIS_JOB_NUMBER
+      })
+    }
+  }
+}
 
 module.exports = function (config) {
-  // Browsers to run on BrowserStack
-  var customLaunchers = {
-    BS_Chrome: {
-      base: 'BrowserStack',
-      os: 'Windows',
-      os_version: '8.1',
-      browser: 'chrome',
-      browser_version: '39.0'
-    },
-    BS_Firefox: {
-      base: 'BrowserStack',
-      os: 'Windows',
-      os_version: '8.1',
-      browser: 'firefox',
-      browser_version: '32.0'
-    },
-    BS_Safari: {
-      base: 'BrowserStack',
-      os: 'OS X',
-      os_version: 'Yosemite',
-      browser: 'safari',
-      browser_version: '8.0'
-    },
-    BS_MobileSafari: {
-      base: 'BrowserStack',
-      os: 'ios',
-      os_version: '7.0',
-      browser: 'iphone',
-      real_mobile: false
-    },
-//    BS_InternetExplorer9: {
-//      base: 'BrowserStack',
-//      os: 'Windows',
-//      os_version: '7',
-//      browser: 'ie',
-//      browser_version: '9.0'
-//    },
-    BS_InternetExplorer10: {
-      base: 'BrowserStack',
-      os: 'Windows',
-      os_version: '8',
-      browser: 'ie',
-      browser_version: '10.0'
-    },
-    BS_InternetExplorer11: {
-      base: 'BrowserStack',
-      os: 'Windows',
-      os_version: '8.1',
-      browser: 'ie',
-      browser_version: '11.0'
-    }
+  var env = process.env
+
+  var isCi = env.CONTINUOUS_INTEGRATION === 'true'
+  var runCoverage = env.COVERAGE === 'true' || isCi
+
+  var coverageLoaders = []
+  var coverageReporters = []
+
+  if (runCoverage) {
+    coverageLoaders.push({
+      test: /\.js$/,
+      include: path.resolve('modules/'),
+      exclude: /__tests__/,
+      loader: 'isparta'
+    })
+
+    coverageReporters.push('coverage')
   }
 
   config.set({
-    customLaunchers: customLaunchers,
-
-    browsers: [ 'Chrome' ],
     frameworks: [ 'mocha' ],
-    reporters: [ 'mocha', 'coverage' ],
 
-    files: [
-      'tests.webpack.js'
-    ],
+    files: [ 'tests.webpack.js' ],
 
     preprocessors: {
       'tests.webpack.js': [ 'webpack', 'sourcemap' ]
     },
 
     webpack: {
-      devtool: 'inline-source-map',
       module: {
         loaders: [
-          { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
-          { test: /\.js$/, exclude: /__tests__/, include: path.resolve('modules/'), loader: 'isparta' }
-        ]
+          { test: /\.js$/, exclude: /node_modules/, loader: 'babel' }
+        ].concat(coverageLoaders)
       },
       plugins: [
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': JSON.stringify('test')
         })
-      ]
+      ],
+      devtool: 'inline-source-map'
     },
 
-    webpackServer: {
+    webpackMiddleware: {
       noInfo: true
     },
+
+    reporters: [ 'mocha' ].concat(coverageReporters),
 
     coverageReporter: {
       reporters: [
         { type: 'html', subdir: 'html' },
         { type: 'lcovonly', subdir: '.' }
       ]
-    }
+    },
+
+    browsers: [ 'Chrome' ],
+
+    singleRun: isCi
   })
 
-  if (process.env.USE_CLOUD) {
-    config.browsers = Object.keys(customLaunchers)
-    config.reporters = [ 'dots', 'coverage' ]
-    config.browserDisconnectTimeout = 10000
-    config.browserDisconnectTolerance = 3
-    config.browserNoActivityTimeout = 30000
-    config.captureTimeout = 120000
-
-    if (process.env.TRAVIS) {
-      var buildLabel = 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')'
-
-      config.browserStack = {
-        username: process.env.BROWSER_STACK_USERNAME,
-        accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
-        pollingTimeout: 10000,
-        startTunnel: false,
-        project: 'react-router',
-        build: buildLabel,
-        name: process.env.TRAVIS_JOB_NUMBER
-      }
-
-      config.singleRun = true
-    } else {
-      config.browserStack = {
-        username: process.env.BROWSER_STACK_USERNAME,
-        accessKey: process.env.BROWSER_STACK_ACCESS_KEY,
-        pollingTimeout: 10000,
-        startTunnel: true
-      }
-    }
-  }
+  setBrowserStack(config, 'react-router')
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "karma-browserstack-launcher": "^0.1.4",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.3",
-    "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
     "karma-sourcemap-loader": "^0.3.5",

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,2 +1,2 @@
-var context = require.context('./modules', true, /-test\.js$/);
-context.keys().forEach(context);
+const context = require.context('./modules', true, /-test\.js$/)
+context.keys().forEach(context)


### PR DESCRIPTION
Per https://github.com/rackt/react-router/pull/2492#issuecomment-155583252, separate from the question of ES5 v ES6, this had some actual config updates like not adding coverage instrumentation to standard testing runs that I think we want for now.