### PR TITLE
Add higher-order component connectHistory()

### DIFF
--- a/modules/__tests__/connectHistory-test.js
+++ b/modules/__tests__/connectHistory-test.js
@@ -1,0 +1,43 @@
+import expect from 'expect'
+import React from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
+import Router from '../Router'
+import Route from '../Route'
+import connectHistory from '../connectHistory'
+import createHistory from 'history/lib/createMemoryHistory'
+
+describe('History Higher-Order Component', function () {
+
+  let node
+  beforeEach(function () {
+    node = document.createElement('div')
+  })
+
+  afterEach(function () {
+    unmountComponentAtNode(node)
+  })
+
+  it('passes the history to the component instance as a prop', function (done) {
+    const history = createHistory('/')
+
+    const Container = React.createClass({
+      render() {
+        return <div><Component/></div>
+      }
+    })
+
+    const Component = connectHistory(React.createClass({
+      componentWillMount() {
+        expect(this.props.history).toExist()
+      },
+      render() { return null }
+    }))
+
+    render((
+      <Router history={history}>
+        <Route path="/" component={Container} />
+      </Router>
+    ), node, done)
+  })
+
+})

--- a/modules/connectHistory.js
+++ b/modules/connectHistory.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react'
+import warning from 'warning'
+import { history } from './PropTypes'
+
+/**
+ * A higher-order-component that passes "history" as a property to components.
+ */
+
+function connectHistory(WrappedComponent) {
+  class ConnectHistory extends Component {
+    render() {
+      warning(
+        this.props.history == null,
+        'The passed prop "history" will be overwritten by connectHistory()'
+      )
+      return <WrappedComponent {...this.props} history={this.context.history} />
+    }
+  }
+
+  ConnectHistory.contextTypes = { history }
+  ConnectHistory.displayName = `ConnectHistory(${getDisplayName(WrappedComponent)})`
+  ConnectHistory.WrappedComponent = WrappedComponent
+
+  return ConnectHistory
+}
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
+export default connectHistory

--- a/modules/index.js
+++ b/modules/index.js
@@ -14,6 +14,9 @@ export History from './History'
 export Lifecycle from './Lifecycle'
 export RouteContext from './RouteContext'
 
+/* higher-order components */
+export connectHistory from './connectHistory'
+
 /* utils */
 export useRoutes from './useRoutes'
 export { createRoutes } from './RouteUtils'


### PR DESCRIPTION
This adds a connectHistory higher-order component that makes the history object accessible via props to a wrapped component.

I took my best guess and named the passed-in prop `history`. A warning is logged if it ends up overwriting an existing prop.

## connectHistory
### Proposed API:

```javascript
import { connectHistory } from 'react-router'

class MyComponent extends React.Component {
  handleClick () {
    this.props.history.pushState(null, '/some/path')
  }
  render () {
    return <h1 onClick={() => this.handleClick()}>Click Me!</h1>
  }
}

export default connectHistory(MyComponent)
```
 
I've done my best to follow the repo's practices and guidelines. Let me know if you need adjustments. If this looks good I'm happy to modify the documentation and/or CHANGES.md.