### PR TITLE
add a jsnext:main so we can distribute ES6 modules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## [HEAD]
 
+### Distribute ES6/ES2015 modules for Rollup optimization
+
+See the [Rollup repo](https://github.com/rollup/rollup#a-next-generation-es6-module-bundler) for more details
+
 ## [v1.1.0]
 
 ### Router `onUpdate` prop

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using [npm](https://www.npmjs.com/):
 
 Note that you need to also install the [history](https://www.npmjs.com/package/history) package since it is a peer dependency of React Router and won't automatically be installed for you in npm 3+.
 
-Then with a module bundler like [webpack](https://webpack.github.io/), use as you would anything else:
+Then with a module bundler like [webpack](https://webpack.github.io/) or [rollup](https://github.com/rollup/rollup), use as you would anything else:
 
 ```js
 // using an ES6 transpiler, like babel

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "*.md",
     "docs",
     "lib",
+    "modules",
     "npm-scripts",
     "umd"
   ],
   "main": "lib/index",
+  "jsnext:main": "modules/index",
   "repository": {
     "type": "git",
     "url": "https://github.com/rackt/react-router.git"


### PR DESCRIPTION
Also add modules to the distribution files and relevant docs to README and CHANGES.

See https://github.com/rollup/rollup#can-i-distribute-my-package-as-an-es6-module