### PR TITLE
Point to v1.0.0 docs instead of master docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <html>
 <head>
 <script>
-window.location = 'https://github.com/rackt/react-router/tree/master/docs';
+window.location = 'https://github.com/rackt/react-router/tree/v1.0.0/docs';
 </script>
 </head>
 <body>
-Redirecting to <a href='https://github.com/rackt/react-router/tree/master/docs'>https://github.com/rackt/react-router/tree/master/docs</a>...
+Redirecting to <a href='https://github.com/rackt/react-router/tree/v1.0.0/docs'>https://github.com/rackt/react-router/tree/v1.0.0/docs</a>...
 </body>
 </html>


### PR DESCRIPTION
Now that we have a v1.0.0, the docs page should probably point there for now as a stopgap.

The goal is to limit the risk of confusing users by showing them documentation for features on master that aren't yet in the stable release.