### PR TITLE
Add ES6 module build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+es6
 lib
 umd
 examples/**/*-bundle.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## [HEAD]
 
+- Add ES2015 module build ([#2530])
 
+[#2530]: https://github.com/rackt/react-router/pull/2530
 
 ## [v1.0.0]
 
@@ -355,5 +357,3 @@ To cancel a "transition from", please refer to the
 
 There's a lot of the old API we've missed, please give the [new
 docs](/docs) a read and help us fill this guide in. Thanks!
-
-

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Using [npm](https://www.npmjs.com/):
 
 Note that you need to also install the [history](https://www.npmjs.com/package/history) package since it is a peer dependency of React Router and won't automatically be installed for you in npm 3+.
 
-Then with a module bundler like [webpack](https://webpack.github.io/), use as you would anything else:
+Then with a module bundler like [webpack](https://webpack.github.io/) that supports either CommonJS or ES2015 modules, use as you would anything else:
 
 ```js
 // using an ES6 transpiler, like babel

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "files": [
     "*.md",
     "docs",
+    "es6",
     "lib",
     "npm-scripts",
     "umd"
   ],
   "main": "lib/index",
+  "jsnext:main": "es6/index",
   "repository": {
     "type": "git",
     "url": "https://github.com/rackt/react-router.git"
@@ -17,7 +19,9 @@
   "homepage": "https://rackt.github.io/react-router/",
   "bugs": "https://github.com/rackt/react-router/issues",
   "scripts": {
-    "build": "rimraf lib && babel ./modules -d lib --ignore '__tests__'",
+    "build": "npm run build-cjs && npm run build-es6",
+    "build-cjs": "rimraf lib && babel ./modules -d lib --ignore '__tests__'",
+    "build-es6": "rimraf es6 && babel ./modules -d es6 --blacklist=es6.modules --ignore '__tests__'",
     "build-umd": "NODE_ENV=production webpack modules/index.js umd/ReactRouter.js",
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/ReactRouter.min.js",
     "lint": "eslint modules examples",


### PR DESCRIPTION
Closes https://github.com/rackt/react-router/issues/2524. Replaces #2523.

~~Don't merge this, it's just a strawman to show what we'd have to change.~~