### PR TITLE
Remove static properties for ie8 compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,8 @@
   "loose": "all",
   "plugins": [
     "dev-expression"
+  ],
+  "blacklist": [
+    "es7.classProperties"
   ]
 }

--- a/modules/IndexRedirect.js
+++ b/modules/IndexRedirect.js
@@ -11,26 +11,6 @@ const { string, object } = React.PropTypes
  */
 class IndexRedirect extends Component {
 
-  static createRouteFromReactElement(element, parentRoute) {
-    /* istanbul ignore else: sanity check */
-    if (parentRoute) {
-      parentRoute.indexRoute = Redirect.createRouteFromReactElement(element)
-    } else {
-      warning(
-        false,
-        'An <IndexRedirect> does not make sense at the root of your route config'
-      )
-    }
-  }
-
-  static propTypes = {
-    to: string.isRequired,
-    query: object,
-    state: object,
-    onEnter: falsy,
-    children: falsy
-  }
-
   /* istanbul ignore next: sanity check */
   render() {
     invariant(
@@ -39,6 +19,26 @@ class IndexRedirect extends Component {
     )
   }
 
+}
+
+IndexRedirect.propTypes = {
+  to: string.isRequired,
+  query: object,
+  state: object,
+  onEnter: falsy,
+  children: falsy
+}
+
+IndexRedirect.createRouteFromReactElement = function (element, parentRoute) {
+  /* istanbul ignore else: sanity check */
+  if (parentRoute) {
+    parentRoute.indexRoute = Redirect.createRouteFromReactElement(element)
+  } else {
+    warning(
+      false,
+      'An <IndexRedirect> does not make sense at the root of your route config'
+    )
+  }
 }
 
 export default IndexRedirect

--- a/modules/IndexRoute.js
+++ b/modules/IndexRoute.js
@@ -12,26 +12,6 @@ const { func } = React.PropTypes
  */
 class IndexRoute extends Component {
 
-  static createRouteFromReactElement(element, parentRoute) {
-    /* istanbul ignore else: sanity check */
-    if (parentRoute) {
-      parentRoute.indexRoute = createRouteFromReactElement(element)
-    } else {
-      warning(
-        false,
-        'An <IndexRoute> does not make sense at the root of your route config'
-      )
-    }
-  }
-
-  static propTypes = {
-    path: falsy,
-    component,
-    components,
-    getComponent: func,
-    getComponents: func
-  }
-
   /* istanbul ignore next: sanity check */
   render() {
     invariant(
@@ -39,7 +19,27 @@ class IndexRoute extends Component {
       '<IndexRoute> elements are for router configuration only and should not be rendered'
     )
   }
+  
+}
 
+IndexRoute.propTypes = {
+  path: falsy,
+  component,
+  components,
+  getComponent: func,
+  getComponents: func
+}
+
+IndexRoute.createRouteFromReactElement = function (element, parentRoute) {
+  /* istanbul ignore else: sanity check */
+  if (parentRoute) {
+    parentRoute.indexRoute = createRouteFromReactElement(element)
+  } else {
+    warning(
+      false,
+      'An <IndexRoute> does not make sense at the root of your route config'
+    )
+  }
 }
 
 export default IndexRoute

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -38,26 +38,6 @@ function isEmptyObject(object) {
  */
 class Link extends Component {
 
-  static contextTypes = {
-    history: object
-  }
-
-  static propTypes = {
-    to: string.isRequired,
-    query: object,
-    hash: string,
-    state: object,
-    activeStyle: object,
-    activeClassName: string,
-    onlyActiveOnIndex: bool.isRequired,
-    onClick: func
-  }
-
-  static defaultProps = {
-    onlyActiveOnIndex: false,
-    className: '',
-    style: {}
-  }
 
   handleClick(event) {
     let allowTransition = true
@@ -120,6 +100,27 @@ class Link extends Component {
     return <a {...props} />
   }
 
+}
+
+Link.contextTypes = {
+  history: object
+}
+
+Link.propTypes = {
+  to: string.isRequired,
+  query: object,
+  hash: string,
+  state: object,
+  activeStyle: object,
+  activeClassName: string,
+  onlyActiveOnIndex: bool.isRequired,
+  onClick: func
+}
+
+Link.defaultProps = {
+  onlyActiveOnIndex: false,
+  className: '',
+  style: {}
 }
 
 export default Link

--- a/modules/Redirect.js
+++ b/modules/Redirect.js
@@ -15,62 +15,6 @@ const { string, object } = React.PropTypes
  */
 class Redirect extends Component {
 
-  static createRouteFromReactElement(element) {
-    const route = createRouteFromReactElement(element)
-
-    if (route.from)
-      route.path = route.from
-
-    route.onEnter = function (nextState, replaceState) {
-      const { location, params } = nextState
-
-      let pathname
-      if (route.to.charAt(0) === '/') {
-        pathname = formatPattern(route.to, params)
-      } else if (!route.to) {
-        pathname = location.pathname
-      } else {
-        let routeIndex = nextState.routes.indexOf(route)
-        let parentPattern = Redirect.getRoutePattern(nextState.routes, routeIndex - 1)
-        let pattern = parentPattern.replace(/\/*$/, '/') + route.to
-        pathname = formatPattern(pattern, params)
-      }
-
-      replaceState(
-        route.state || location.state,
-        pathname,
-        route.query || location.query
-      )
-    }
-
-    return route
-  }
-
-  static getRoutePattern(routes, routeIndex) {
-    let parentPattern = ''
-
-    for (let i = routeIndex; i >= 0; i--) {
-      let route = routes[i]
-      let pattern = route.path || ''
-      parentPattern = pattern.replace(/\/*$/, '/') + parentPattern
-
-      if (pattern.indexOf('/') === 0)
-        break
-    }
-
-    return '/' + parentPattern
-  }
-
-  static propTypes = {
-    path: string,
-    from: string, // Alias for path
-    to: string.isRequired,
-    query: object,
-    state: object,
-    onEnter: falsy,
-    children: falsy
-  }
-
   /* istanbul ignore next: sanity check */
   render() {
     invariant(
@@ -79,6 +23,62 @@ class Redirect extends Component {
     )
   }
 
+}
+
+Redirect.createRouteFromReactElement = function (element) {
+  const route = createRouteFromReactElement(element)
+
+  if (route.from)
+    route.path = route.from
+
+  route.onEnter = function (nextState, replaceState) {
+    const { location, params } = nextState
+
+    let pathname
+    if (route.to.charAt(0) === '/') {
+      pathname = formatPattern(route.to, params)
+    } else if (!route.to) {
+      pathname = location.pathname
+    } else {
+      let routeIndex = nextState.routes.indexOf(route)
+      let parentPattern = Redirect.getRoutePattern(nextState.routes, routeIndex - 1)
+      let pattern = parentPattern.replace(/\/*$/, '/') + route.to
+      pathname = formatPattern(pattern, params)
+    }
+
+    replaceState(
+      route.state || location.state,
+      pathname,
+      route.query || location.query
+    )
+  }
+
+  return route
+}
+
+Redirect.getRoutePattern = function (routes, routeIndex) {
+  let parentPattern = ''
+
+  for (let i = routeIndex; i >= 0; i--) {
+    let route = routes[i]
+    let pattern = route.path || ''
+    parentPattern = pattern.replace(/\/*$/, '/') + parentPattern
+
+    if (pattern.indexOf('/') === 0)
+      break
+  }
+
+  return '/' + parentPattern
+}
+
+Redirect.propTypes = {
+  path: string,
+  from: string, // Alias for path
+  to: string.isRequired,
+  query: object,
+  state: object,
+  onEnter: falsy,
+  children: falsy
 }
 
 export default Redirect

--- a/modules/Route.js
+++ b/modules/Route.js
@@ -17,16 +17,6 @@ const { string, func } = React.PropTypes
  */
 class Route extends Component {
 
-  static createRouteFromReactElement = createRouteFromReactElement
-
-  static propTypes = {
-    path: string,
-    component,
-    components,
-    getComponent: func,
-    getComponents: func
-  }
-
   /* istanbul ignore next: sanity check */
   render() {
     invariant(
@@ -35,6 +25,16 @@ class Route extends Component {
     )
   }
 
+}
+
+Route.createRouteFromReactElement = createRouteFromReactElement
+
+Route.propTypes = {
+  path: string,
+  component,
+  components,
+  getComponent: func,
+  getComponents: func
 }
 
 export default Route

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -15,22 +15,6 @@ const { func, object } = React.PropTypes
  */
 class Router extends Component {
 
-  static propTypes = {
-    history: object,
-    children: routes,
-    routes, // alias for children
-    RoutingContext: func.isRequired,
-    createElement: func,
-    onError: func,
-    onUpdate: func,
-    parseQueryString: func,
-    stringifyQuery: func
-  }
-
-  static defaultProps = {
-    RoutingContext
-  }
-
   constructor(props, context) {
     super(props, context)
 
@@ -105,6 +89,22 @@ class Router extends Component {
     })
   }
 
+}
+
+Router.propTypes = {
+  history: object,
+  children: routes,
+  routes, // alias for children
+  RoutingContext: func.isRequired,
+  createElement: func,
+  onError: func,
+  onUpdate: func,
+  parseQueryString: func,
+  stringifyQuery: func
+}
+
+Router.defaultProps = {
+  RoutingContext
 }
 
 export default Router

--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -11,24 +11,6 @@ const { array, func, object } = React.PropTypes
  */
 class RoutingContext extends Component {
 
-  static propTypes = {
-    history: object.isRequired,
-    createElement: func.isRequired,
-    location: object.isRequired,
-    routes: array.isRequired,
-    params: object.isRequired,
-    components: array.isRequired
-  }
-
-  static defaultProps = {
-    createElement: React.createElement
-  }
-
-  static childContextTypes = {
-    history: object.isRequired,
-    location: object.isRequired
-  }
-
   getChildContext() {
     const { history, location } = this.props
     return { history, location }
@@ -88,6 +70,24 @@ class RoutingContext extends Component {
     return element
   }
 
+}
+
+RoutingContext.propTypes = {
+  history: object.isRequired,
+  createElement: func.isRequired,
+  location: object.isRequired,
+  routes: array.isRequired,
+  params: object.isRequired,
+  components: array.isRequired
+}
+
+RoutingContext.defaultProps = {
+  createElement: React.createElement
+}
+
+RoutingContext.childContextTypes = {
+  history: object.isRequired,
+  location: object.isRequired
 }
 
 export default RoutingContext

--- a/modules/__tests__/RouteComponent-test.js
+++ b/modules/__tests__/RouteComponent-test.js
@@ -44,10 +44,7 @@ describe('a Route Component', function () {
 
   it('receives the right context', function (done) {
     class RouteComponent extends Component {
-      static contextTypes = {
-        history: object.isRequired,
-        location: object.isRequired
-      }
+      
       componentDidMount() {
         expect(this.context.history).toEqual(this.props.history)
         expect(this.context.location).toEqual(this.props.location)
@@ -55,6 +52,11 @@ describe('a Route Component', function () {
       render() {
         return null
       }
+    }
+    
+    RouteComponent.contextTypes = {
+      history: object.isRequired,
+      location: object.isRequired
     }
 
     const route = { path: '/', component: RouteComponent }

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -255,11 +255,11 @@ describe('Router', function () {
       const Child = () => <span>child</span>
 
       class LabelWrapper extends Component {
-        static defaultProps = {
-          createElement: React.createElement
+        constructor() {
+          this.createElement = this.createElement.bind(this)
         }
 
-        createElement = (component, props) => {
+        createElement(component, props) {
           const { label, createElement } = this.props
 
           return (
@@ -281,6 +281,10 @@ describe('Router', function () {
             </span>
           )
         }
+      }
+
+      LabelWrapper.defaultProps = {
+        createElement: React.createElement
       }
 
       const CustomRoutingContext = props => (


### PR DESCRIPTION
By removing usages of [class-properties](https://babeljs.io/docs/plugins/transform-class-properties/) which are still experimental, ie8 is fully supported. We also protect against it happening in the future with a blacklist of that feature in babel. 