### PR TITLE
Run the server rendering test against Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/ReactRouter.min.js",
     "lint": "eslint modules examples",
     "start": "node examples/server.js",
-    "test": "npm run lint && karma start",
+    "test": "npm run lint && npm run test-node && npm run test-browser",
+    "test-browser": "karma start",
+    "test-node": "mocha --compilers js:babel-core/register tests.node.js",
     "postinstall": "node ./npm-scripts/postinstall.js"
   },
   "authors": [

--- a/tests.node.js
+++ b/tests.node.js
@@ -1,0 +1,1 @@
+import './modules/__tests__/serverRendering-test'


### PR DESCRIPTION
Closes https://github.com/rackt/react-router/issues/2538

Just the SSR test for now - we can add more later if we want, but this is the one we really care about.

Not generating coverage for this right now, since we're not merging coverage data across platforms.