### PR TITLE
add 'replace' as props to <Link>

### DIFF
--- a/modules/Link.js
+++ b/modules/Link.js
@@ -83,11 +83,13 @@ class Link extends Component {
     event.preventDefault()
 
     if (allowTransition) {
-      let { state, to, query, hash } = this.props
+      let { state, to, query, hash , replace} = this.props
 
       if (hash)
         to += hash
-
+      
+      replace?
+      this.context.history.replaceState(state, to, query):
       this.context.history.pushState(state, to, query)
     }
   }


### PR DESCRIPTION
We need 'replaceState' rather than 'pushState' sometimes. 
For example : Tabs.