### PR TITLE
Allow createRoutesFromReactChildren to return an array

### DIFF
--- a/modules/RouteUtils.js
+++ b/modules/RouteUtils.js
@@ -72,8 +72,12 @@ export function createRoutesFromReactChildren(children, parentRoute) {
       if (element.type.createRouteFromReactElement) {
         const route = element.type.createRouteFromReactElement(element, parentRoute)
 
-        if (route)
-          routes.push(route)
+        if (route) {
+          if (Array.isArray(route))
+            routes.push(...route)
+          else
+            routes.push(route)
+        }
       } else {
         routes.push(createRouteFromReactElement(element))
       }

--- a/modules/__tests__/createRoutesFromReactChildren-test.js
+++ b/modules/__tests__/createRoutesFromReactChildren-test.js
@@ -29,6 +29,21 @@ describe('createRoutesFromReactChildren', function () {
     }
   }
 
+  class RouteComposite extends Route {
+  }
+  RouteComposite.createRouteFromReactElement = function () {
+    return [
+      {
+        path: '/one',
+        component: Hello
+      },
+      {
+        path: '/two',
+        component: Goodbye
+      }
+    ]
+  }
+
   it('works with index routes', function () {
     const routes = createRoutesFromReactChildren(
       <Route path="/" component={Parent}>
@@ -104,6 +119,23 @@ describe('createRoutesFromReactChildren', function () {
             component: Hello
           }
         ]
+      }
+    ])
+  })
+
+  it('allows createRouteFromReactElement to return an array', function () {
+    const routes = createRoutesFromReactChildren(
+      <RouteComposite />
+    )
+
+    expect(routes).toEqual([
+      {
+        path: '/one',
+        component: Hello
+      },
+      {
+        path: '/two',
+        component: Goodbye
       }
     ])
   })


### PR DESCRIPTION
This allows me to have Higher Order Routes.
In my case I want to protect all child routes by intercepting onEnter of each route and redirect if user has no permission for this route.

```jsx
<InterceptRoutes onEnter={secureRoute}>
  <Route path="/" component={App} access="ROLE_USER">
    <Route path="dashboard" component={Dashboard} />
  </Route>
  <Route path="/login" component={Login} />
  <Route path="/logout" component={Logout} />
</InterceptRoutes>
```