### PR TITLE
Add listenRoutes to useRoutes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,14 @@
 ## [HEAD]
 
+- Expose `listenRoutes` on `useRoutes`-enhanced histories for listening to
+  routing state ([#2580])
 - Support IE8 ([#2540])
 - Add ES2015 module build ([#2530])
 
 [HEAD]: https://github.com/rackt/react-router/compare/latest...HEAD
 [#2530]: https://github.com/rackt/react-router/pull/2530
 [#2540]: https://github.com/rackt/react-router/pull/2540
+[#2580]: https://github.com/rackt/react-router/pull/2580
 
 ## [v1.0.0]
 > Nov 9, 2015

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -45,7 +45,7 @@ class Router extends Component {
       stringifyQuery
     })
 
-    this._unlisten = this.history.listen((error, state) => {
+    this._unlisten = this.history.listenRoutes((error, state) => {
       if (error) {
         this.handleError(error)
       } else {

--- a/modules/useRoutes.js
+++ b/modules/useRoutes.js
@@ -218,7 +218,7 @@ function useRoutes(createHistory) {
      * changes, we update state and call the listener. We can also
      * gracefully handle errors and redirects.
      */
-    function listen(listener) {
+    function listenRoutes(listener) {
       // TODO: Only use a single history listener. Otherwise we'll
       // end up with multiple concurrent calls to match.
       return history.listen(function (location) {
@@ -244,11 +244,22 @@ function useRoutes(createHistory) {
       })
     }
 
+    function listen(listener) {
+      warning(
+        '[React Router] The behavior of `listen` will change to match ' +
+        'standard histories. Use `listenRoutes` to listen to routing state.'
+      )
+      return listenRoutes(listener)
+    }
+
     return {
       ...history,
       isActive,
       match,
       listenBeforeLeavingRoute,
+      listenRoutes,
+
+      // Deprecated:
       listen
     }
   }


### PR DESCRIPTION
Closes https://github.com/rackt/react-router/issues/2502

This opens up subsequent possibilities for accepting histories on `<Router>` that have already been enhanced with `useRoutes` or an equivalent, which will expose further customization options for users.

That will be for another PR, though.