### PR TITLE
expose router state in the `onUpdate` hook

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -71,7 +71,7 @@ A function used to convert a query string into an object that gets passed to rou
 ##### `onError(error)`
 While the router is matching, errors may bubble up, here is your opportunity to catch and deal with them. Typically these will come from async features like [`route.getComponents`](#getcomponentscallback), [`route.getIndexRoute`](#getindexroutecallback), and [`route.getChildRoutes`](#getchildrouteslocation-callback).
 
-##### `onUpdate()`
+##### `onUpdate(routerState)`
 Called whenever the router updates its state in response to URL changes.
 
 #### Examples

--- a/examples/huge-apps/app.js
+++ b/examples/huge-apps/app.js
@@ -24,8 +24,12 @@ const rootRoute = {
   } ]
 }
 
+function analyticsLog(state) {
+  console.log('log to analytics: ' + state.location.pathname);
+}
+
 render(
-  <Router history={history} routes={rootRoute} />,
+  <Router history={history} routes={rootRoute} onUpdate={analyticsLog} />,
   document.getElementById('example')
 )
 

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -49,7 +49,7 @@ class Router extends Component {
       if (error) {
         this.handleError(error)
       } else {
-        this.setState(state, this.props.onUpdate)
+        this.setState(state, this.props.onUpdate && this.props.onUpdate.bind(this, state) )
       }
     })
   }

--- a/modules/__tests__/Router-test.js
+++ b/modules/__tests__/Router-test.js
@@ -5,6 +5,7 @@ import createHistory from 'history/lib/createMemoryHistory'
 import Route from '../Route'
 import Router from '../Router'
 import RoutingContext from '../RoutingContext'
+import execSteps from './execSteps'
 
 describe('Router', function () {
 
@@ -456,6 +457,28 @@ describe('Router', function () {
           </Router>
         ), node)
       }).toThrow('error fixture')
+    })
+  })
+
+  describe('update callback', function () {
+    it('should call onUpdate with its state', function (done) {
+      const steps = [
+        function () {
+          this.history.pushState(null, '/hello')
+        },
+        function (routerState) {
+          expect(routerState.location.pathname).toEqual('/hello')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={createHistory('/')} onUpdate={execNextStep}>
+          <Route path="/" component={Parent} />
+          <Route path="hello" component={Child} />
+        </Router>
+      ), node, execNextStep)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/ReactRouter.min.js",
     "lint": "eslint modules examples",
     "start": "node examples/server.js",
-    "test": "npm run lint && npm run test-node && npm run test-browser",
+    "test": "npm run test-node && npm run test-browser",
     "test-browser": "karma start",
     "test-node": "mocha --compilers js:babel-core/register tests.node.js",
     "postinstall": "node ./npm-scripts/postinstall.js"


### PR DESCRIPTION
Currently this hook is a bit useless without the state of the router. This PR exposes it.

It allows to plug analytics super easily (as in the example). 