### PR TITLE
add a Note and example how to actually return the expected definition for a getIndexRoute callback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -367,8 +367,8 @@ All the same props as [Route](#route) except for `path`.
 ##### `getIndexRoute(location, callback)`
 Same as `IndexRoute` but asynchronous, useful for
 code-splitting.
-Note: `callback` expects an object with the `component` property set to your
-Component class.
+Note: `callback` expects a route object, with the `component` property set to
+your indexRoute Component class.
 
 ###### `callback` signature
 `cb(err, component)`
@@ -376,8 +376,11 @@ Component class.
 ```js
 <Route path="courses/:courseId" getIndexRoute={(location, cb) => {
   // do asynchronous stuff to find the index route
-  const IndexRoute = require('MyIndexRoute')
-  cb(null, { component: IndexRoute })
+  const IndexRoute = require('./MyIndexRoute')
+  const myIndexRoute = {
+    component: IndexRoute
+  }
+  cb(null, myIndexRoute)
 }}/>
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -367,6 +367,8 @@ All the same props as [Route](#route) except for `path`.
 ##### `getIndexRoute(location, callback)`
 Same as `IndexRoute` but asynchronous, useful for
 code-splitting.
+Note: `callback` expects an object with the `component` property set to your
+Component class.
 
 ###### `callback` signature
 `cb(err, component)`
@@ -374,7 +376,8 @@ code-splitting.
 ```js
 <Route path="courses/:courseId" getIndexRoute={(location, cb) => {
   // do asynchronous stuff to find the index route
-  cb(null, myIndexRoute)
+  const IndexRoute = require('MyIndexRoute')
+  cb(null, { component: IndexRoute })
 }}/>
 ```
 


### PR DESCRIPTION
This issue has been pointed out in #2572 but the documentation remained unclear because there is still no mention that the callback should be resolved with an object of the form:
```js
{
  component: MyComponentClass
}
``` 
I think it makes sense to be explicit about the expected object instead of just saying just `myIndexRoute`(as it currently stands in the docs). I spent >30minutes trying to figure out why my IndexRoute was not being mounted correctly :8ball: 