### PR TITLE
Explain arguments to `match` callback (in API docs for `match`).

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -23,6 +23,7 @@
 
 * [Utilities](#utilities)
   * [useRoutes](#useroutescreatehistory)
+  * [match](#matchlocation-cb)
   * [createRoutes](#createroutesroutes)
   * [PropTypes](#proptypes)
 
@@ -657,8 +658,14 @@ Returns a new `createHistory` function that may be used to create history object
 
 This function is to be used for server-side rendering. It matches a set of routes to a location, without rendering, and calls a `callback(error, redirectLocation, renderProps)` when it's done.
 
-*Note: You probably don't want to use this in a browser. Use the [`history.listen`](https://github.com/rackt/history/blob/master/docs/GettingStarted.md#getting-started) API instead.*
+The three arguments to the callback function you pass to `match` are:
+* `error`: A Javascript `Error` object if an error occurred, `undefined` otherwise.
+* `redirectLocation`: A [Location](/docs/Glossary.md#location) object if the route is a redirect, `undefined` otherwise.
+* `renderProps`: The props you should pass to the routing context if the route matched, `undefined` otherwise.
 
+If all three parameters are `undefined`, this means that there was no route found matching the given location.
+
+*Note: You probably don't want to use this in a browser unless you're doing server-side rendering of async routes.*
 
 
 ## `createRoutes(routes)`


### PR DESCRIPTION
Added extra docs in API.md, leaving ServerRendering.md as is.
Fixes #2622 
SEE https://github.com/rackt/react-router/pull/2629