### PR TITLE
Remove getQueryParams()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -312,8 +312,7 @@ where you can get it now if you are **not** a route component
 |-------------------|------------------------------------|
 | `getPath()`       | `location.pathname+location.search`|
 | `getPathname()`   | `location.pathname`                |
-| `getQuery()`      | `location.search`                  |
-| `getQueryParams()`| `location.query`                   |
+| `getQuery()`      | `location.query`                   |
 | `isActive(to, params, query)` | `history.isActive(pathname, query, indexOnly)` |
 
 Note not all `State` functionality can be accessed via context in v1.0.


### PR DESCRIPTION
In version 13 there was no `getQueryParams()`. `getQuery` returns the object.

https://github.com/rackt/react-router/blob/0.13.x/doc/06%20Mixins/State.md