### PR TITLE
Update Histories.md

### DIFF
--- a/docs/guides/basics/Histories.md
+++ b/docs/guides/basics/Histories.md
@@ -35,10 +35,29 @@ The DOM API that hash history uses to transition around is simply `window.locati
 
 You can disable that feature (more [here](http://rackt.org/history/stable/HashHistoryCaveats.html)):
 ```js
+// JavaScript module import
+import createHistory from 'history/lib/createHistory'
+// or commonjs
+const createHistory = require('history/lib/createHistory')
+
+// ...
+
 // Opt-out of persistent state, not recommended.
 let history = createHistory({
   queryKey: false
 });
+
+// ...
+
+render(
+  <Router history={ history }>
+    <Route path='/' component={App}>
+      // ... 
+    </Route>
+  </Router>,
+  document.getElementById('app')
+)
+
 ```
 
 ### `createBrowserHistory`


### PR DESCRIPTION
Clarify how to opt out of persistent state in the hash based routing solution.  

Since the hash based routing solution is the default (and so works without explicit imports) I thought it might be worth highlighting what exactly should be imported in order to do this. 

When implementing this myself I needed to do a little digging and wanted to save others the effort.