### PR TITLE
Add <Router render> prop, remove <Router RoutingContext>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -192,6 +192,9 @@ const Lifecycle = {
 }
 ```
 
+### Router render prop
+
+Just a stub so we don't forget to talk about it.
 
 
 ## [v1.0.1]

--- a/docs/API.md
+++ b/docs/API.md
@@ -75,6 +75,10 @@ While the router is matching, errors may bubble up, here is your opportunity to 
 ##### `onUpdate()`
 Called whenever the router updates its state in response to URL changes.
 
+##### `render(props)`
+This is primarily for integrating with other libraries that need to participate in rendering before the route components are rendered. It defaults to `render={(props) => <RoutingContext {...props}/>}`.
+
+
 #### Examples
 Please see the [`examples/`](/examples) directory of the repository for extensive examples of using `Router`.
 

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -19,7 +19,7 @@ const Router = React.createClass({
     history: object,
     children: routes,
     routes, // alias for children
-    RoutingContext: func.isRequired,
+    render: func,
     createElement: func,
     onError: func,
     onUpdate: func,
@@ -29,7 +29,9 @@ const Router = React.createClass({
 
   getDefaultProps() {
     return {
-      RoutingContext
+      render(props) {
+        return <RoutingContext {...props} />
+      }
     }
   },
 
@@ -90,8 +92,8 @@ const Router = React.createClass({
   },
 
   render() {
-    let { location, routes, params, components } = this.state
-    let { RoutingContext, createElement, ...props } = this.props
+    const { location, routes, params, components } = this.state
+    const { createElement, render, ...props } = this.props
 
     if (location == null)
       return null // Async match
@@ -100,14 +102,14 @@ const Router = React.createClass({
     // the only ones that might be custom routing context props.
     Object.keys(Router.propTypes).forEach(propType => delete props[propType])
 
-    return React.createElement(RoutingContext, {
+    return render({
       ...props,
       history: this.history,
-      createElement,
       location,
       routes,
       params,
-      components
+      components,
+      createElement
     })
   }
 

--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -14,11 +14,11 @@ const RoutingContext = React.createClass({
 
   propTypes: {
     history: object.isRequired,
-    createElement: func.isRequired,
     location: object.isRequired,
     routes: array.isRequired,
     params: object.isRequired,
-    components: array.isRequired
+    components: array.isRequired,
+    createElement: func.isRequired
   },
 
   getDefaultProps() {

--- a/modules/__tests__/RoutingContext-test.js
+++ b/modules/__tests__/RoutingContext-test.js
@@ -4,7 +4,7 @@ import { render, unmountComponentAtNode } from 'react-dom'
 import RoutingContext from '../RoutingContext'
 import match from '../match'
 
-describe('For Real RoutingContext', () => {
+describe('RoutingContext', () => {
   let node, routes, context, history
 
   beforeEach(() => {


### PR DESCRIPTION
We shouldn't need to deprecate <Router RoutingContext> since I don't think we ever actually documented it.

As was the case w #2647, we shouldn't need to update CHANGES.md just yet. We'll need to update it more comprehensively when everything lands.