### PR TITLE
Rename RoutingContext -> RouterContext

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,14 @@ const Lifecycle = {
 
 Just a stub so we don't forget to talk about it.
 
+### `RoutingContext` renamed to `RouterContext`
+
+```js
+// v1.0.x
+import { RoutingContext } from 'react-router'
+// v1.1.0
+import { RouterContext } from 'react-router'
+```
 
 ## [v1.0.1]
 > Dec 5, 2015

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,7 +4,8 @@
   - [Router](#router)
   - [Link](#link)
   - [IndexLink](#indexlink)
-  - [RoutingContext](#routingcontext)
+  - [RouterContext](#routercontext)
+  - RoutingContext (Deprecated, use `RouterContext`)
 
 * [Configuration Components](#configuration-components)
   - [Route](#route)
@@ -76,7 +77,7 @@ While the router is matching, errors may bubble up, here is your opportunity to 
 Called whenever the router updates its state in response to URL changes.
 
 ##### `render(props)`
-This is primarily for integrating with other libraries that need to participate in rendering before the route components are rendered. It defaults to `render={(props) => <RoutingContext {...props}/>}`.
+This is primarily for integrating with other libraries that need to participate in rendering before the route components are rendered. It defaults to `render={(props) => <RouterContext {...props}/>}`.
 
 
 #### Examples
@@ -136,8 +137,8 @@ Given a route like `<Route path="/users/:userId" />`:
 ### IndexLink
 Docs coming so soon!
 
-### RoutingContext
-A `<RoutingContext>` renders the component tree for a given router state and sets the history object and the current location in context.
+### RouterContext
+A `<RouterContext>` renders the component tree for a given router state and sets the history object and the current location in context.
 
 
 

--- a/docs/guides/advanced/ServerRendering.md
+++ b/docs/guides/advanced/ServerRendering.md
@@ -9,13 +9,13 @@ Server rendering is a bit different than in a client because you'll want to:
 To facilitate these needs, you drop one level lower than the [`<Router>`](/docs/API.md#Router) API with:  
 
 - [`match`](https://github.com/rackt/react-router/blob/master/docs/API.md#matchlocation-cb) to match the routes to a location without rendering
-- `RoutingContext` for synchronous rendering of route components
+- `RouterContext` for synchronous rendering of route components
 
 It looks something like this with an imaginary JavaScript server:
 
 ```js
 import { renderToString } from 'react-dom/server'
-import { match, RoutingContext } from 'react-router'
+import { match, RouterContext } from 'react-router'
 import routes from './routes'
 
 serve((req, res) => {
@@ -27,7 +27,7 @@ serve((req, res) => {
     } else if (redirectLocation) {
       res.redirect(302, redirectLocation.pathname + redirectLocation.search)
     } else if (renderProps) {
-      res.status(200).send(renderToString(<RoutingContext {...renderProps} />))
+      res.status(200).send(renderToString(<RouterContext {...renderProps} />))
     } else {
       res.status(404).send('Not found')
     }

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -2,7 +2,7 @@ import React from 'react'
 import warning from 'warning'
 import createHashHistory from 'history/lib/createHashHistory'
 import { createRoutes } from './RouteUtils'
-import RoutingContext from './RoutingContext'
+import RouterContext from './RouterContext'
 import useRoutes from './useRoutes'
 import { routes } from './PropTypes'
 
@@ -10,7 +10,7 @@ const { func, object } = React.PropTypes
 
 /**
  * A <Router> is a high-level API for automatically setting up
- * a router that renders a <RoutingContext> with all the props
+ * a router that renders a <RouterContext> with all the props
  * it needs each time the URL changes.
  */
 const Router = React.createClass({
@@ -30,7 +30,7 @@ const Router = React.createClass({
   getDefaultProps() {
     return {
       render(props) {
-        return <RoutingContext {...props} />
+        return <RouterContext {...props} />
       }
     }
   },

--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -1,0 +1,125 @@
+import React from 'react'
+import invariant from 'invariant'
+import deprecateObjectProperties from './deprecateObjectProperties'
+import { isReactChildren } from './RouteUtils'
+import getRouteParams from './getRouteParams'
+
+const { array, func, object } = React.PropTypes
+
+/**
+ * A <RouterContext> renders the component tree for a given router state
+ * and sets the history object and the current location in context.
+ */
+const RouterContext = React.createClass({
+
+  propTypes: {
+    history: object.isRequired,
+    location: object.isRequired,
+    routes: array.isRequired,
+    params: object.isRequired,
+    components: array.isRequired,
+    createElement: func.isRequired
+  },
+
+  getDefaultProps() {
+    return {
+      createElement: React.createElement
+    }
+  },
+
+  childContextTypes: {
+    history: object.isRequired,
+    location: object.isRequired,
+    router: object.isRequired
+  },
+
+  getChildContext() {
+    const { history, location } = this.props
+    const router = {
+      push(...args) {
+        history.push(...args)
+      },
+      replace(...args) {
+        history.replace(...args)
+      },
+      addRouteLeaveHook(...args) {
+        return history.listenBeforeLeavingRoute(...args)
+      },
+      isActive(...args) {
+        return history.isActive(...args)
+      }
+    }
+    const contextExport = { history, location, router }
+    if (__DEV__)
+      return deprecateObjectProperties(contextExport, {
+        history: '`context.history` is deprecated, please use context.router',
+        location: '`context.location` is deprecated, please use a route component\'s `props.location` instead. If this is a deeply nested component, please refer to the strategies described in https://github.com/rackt/react-router/blob/v1.1.0/CHANGES.md#v110'
+      })
+    else
+      return contextExport
+  },
+
+  createElement(component, props) {
+    return component == null ? null : this.props.createElement(component, props)
+  },
+
+  render() {
+    const { history, location, routes, params, components } = this.props
+    let element = null
+
+    if (components) {
+      element = components.reduceRight((element, components, index) => {
+        if (components == null)
+          return element // Don't create new children; use the grandchildren.
+
+        const route = routes[index]
+        const routeParams = getRouteParams(route, params)
+        const props = {
+          history,
+          location,
+          params,
+          route,
+          routeParams,
+          routes
+        }
+
+        if (isReactChildren(element)) {
+          props.children = element
+        } else if (element) {
+          for (let prop in element)
+            if (element.hasOwnProperty(prop))
+              props[prop] = element[prop]
+        }
+
+        if (typeof components === 'object') {
+          const elements = {}
+
+          for (const key in components) {
+            if (components.hasOwnProperty(key)) {
+              // Pass through the key as a prop to createElement to allow
+              // custom createElement functions to know which named component
+              // they're rendering, for e.g. matching up to fetched data.
+              elements[key] = this.createElement(components[key], {
+                key, ...props
+              })
+            }
+          }
+
+          return elements
+        }
+
+        return this.createElement(components, props)
+      }, element)
+    }
+
+    invariant(
+      element === null || element === false || React.isValidElement(element),
+      'The root route must render a single element'
+    )
+
+    return element
+  }
+
+})
+
+export default RouterContext

--- a/modules/RoutingContext.js
+++ b/modules/RoutingContext.js
@@ -1,125 +1,15 @@
 import React from 'react'
-import invariant from 'invariant'
-import deprecateObjectProperties from './deprecateObjectProperties'
-import { isReactChildren } from './RouteUtils'
-import getRouteParams from './getRouteParams'
+import RouterContext from './RouterContext'
+import warning from 'warning'
 
-const { array, func, object } = React.PropTypes
-
-/**
- * A <RoutingContext> renders the component tree for a given router state
- * and sets the history object and the current location in context.
- */
-const RoutingContext = React.createClass({
-
-  propTypes: {
-    history: object.isRequired,
-    location: object.isRequired,
-    routes: array.isRequired,
-    params: object.isRequired,
-    components: array.isRequired,
-    createElement: func.isRequired
-  },
-
-  getDefaultProps() {
-    return {
-      createElement: React.createElement
-    }
-  },
-
-  childContextTypes: {
-    history: object.isRequired,
-    location: object.isRequired,
-    router: object.isRequired
-  },
-
-  getChildContext() {
-    const { history, location } = this.props
-    const router = {
-      push(...args) {
-        history.push(...args)
-      },
-      replace(...args) {
-        history.replace(...args)
-      },
-      addRouteLeaveHook(...args) {
-        return history.listenBeforeLeavingRoute(...args)
-      },
-      isActive(...args) {
-        return history.isActive(...args)
-      }
-    }
-    const contextExport = { history, location, router }
-    if (__DEV__)
-      return deprecateObjectProperties(contextExport, {
-        history: '`context.history` is deprecated, please use context.router',
-        location: '`context.location` is deprecated, please use a route component\'s `props.location` instead. If this is a deeply nested component, please refer to the strategies described in https://github.com/rackt/react-router/blob/v1.1.0/CHANGES.md#v110'
-      })
-    else
-      return contextExport
-  },
-
-  createElement(component, props) {
-    return component == null ? null : this.props.createElement(component, props)
-  },
-
-  render() {
-    const { history, location, routes, params, components } = this.props
-    let element = null
-
-    if (components) {
-      element = components.reduceRight((element, components, index) => {
-        if (components == null)
-          return element // Don't create new children; use the grandchildren.
-
-        const route = routes[index]
-        const routeParams = getRouteParams(route, params)
-        const props = {
-          history,
-          location,
-          params,
-          route,
-          routeParams,
-          routes
-        }
-
-        if (isReactChildren(element)) {
-          props.children = element
-        } else if (element) {
-          for (let prop in element)
-            if (element.hasOwnProperty(prop))
-              props[prop] = element[prop]
-        }
-
-        if (typeof components === 'object') {
-          const elements = {}
-
-          for (const key in components) {
-            if (components.hasOwnProperty(key)) {
-              // Pass through the key as a prop to createElement to allow
-              // custom createElement functions to know which named component
-              // they're rendering, for e.g. matching up to fetched data.
-              elements[key] = this.createElement(components[key], {
-                key, ...props
-              })
-            }
-          }
-
-          return elements
-        }
-
-        return this.createElement(components, props)
-      }, element)
-    }
-
-    invariant(
-      element === null || element === false || React.isValidElement(element),
-      'The root route must render a single element'
-    )
-
-    return element
+class RoutingContext extends React.Component {
+  componentWillMount() {
+    warning(false, '`RoutingContext` has been renamed to `RouterContext`. Please use `import { RouterContext } from \'react-router\'.`')
   }
 
-})
+  render() {
+    return <RouterContext {...this.props}/>
+  }
+}
 
 export default RoutingContext

--- a/modules/__tests__/RouterContext-test.js
+++ b/modules/__tests__/RouterContext-test.js
@@ -1,10 +1,10 @@
 import expect from 'expect'
 import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom'
-import RoutingContext from '../RoutingContext'
+import RouterContext from '../RouterContext'
 import match from '../match'
 
-describe('RoutingContext', () => {
+describe('RouterContext', () => {
   let node, routes, context, history
 
   beforeEach(() => {
@@ -30,7 +30,7 @@ describe('RoutingContext', () => {
 
   function renderTest(done) {
     match({ location: '/', routes }, (err, redirect, renderProps) => {
-      render(<RoutingContext {...renderProps} history={history} />, node)
+      render(<RouterContext {...renderProps} history={history} />, node)
       done()
     })
   }

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import React, { Component } from 'react'
 import { renderToString } from 'react-dom/server'
 import match from '../match'
-import RoutingContext from '../RoutingContext'
+import RouterContext from '../RoutingContext'
 import Link from '../Link'
 
 describe('server rendering', function () {
@@ -68,7 +68,7 @@ describe('server rendering', function () {
   it('works', function (done) {
     match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
       const string = renderToString(
-        <RoutingContext {...renderProps} />
+        <RouterContext {...renderProps} />
       )
       expect(string).toMatch(/The Dashboard/)
       done()
@@ -78,7 +78,7 @@ describe('server rendering', function () {
   it('renders active Links as active', function (done) {
     match({ routes, location: '/about' }, function (error, redirectLocation, renderProps) {
       const string = renderToString(
-        <RoutingContext {...renderProps} />
+        <RouterContext {...renderProps} />
       )
       expect(string).toMatch(/about-is-active/)
       expect(string).toNotMatch(/dashboard-is-active/)

--- a/modules/index.js
+++ b/modules/index.js
@@ -17,7 +17,7 @@ export RouteContext from './RouteContext'
 /* utils */
 export useRoutes from './useRoutes'
 export { createRoutes } from './RouteUtils'
-export RoutingContext from './RoutingContext'
+export RouterContext from './RouterContext'
 export PropTypes from './PropTypes'
 export match from './match'
 


### PR DESCRIPTION
We only export `router` to context now and would
like to start a precedent that components that
export a context are named after what they export

closes #2650