### PR TITLE
Add more functions from history to context.router

### DIFF
--- a/modules/RouterContext.js
+++ b/modules/RouterContext.js
@@ -36,18 +36,14 @@ const RouterContext = React.createClass({
   getChildContext() {
     const { history, location } = this.props
     const router = {
-      push(...args) {
-        history.push(...args)
-      },
-      replace(...args) {
-        history.replace(...args)
-      },
-      addRouteLeaveHook(...args) {
-        return history.listenBeforeLeavingRoute(...args)
-      },
-      isActive(...args) {
-        return history.isActive(...args)
-      }
+      push: history.push,
+      replace: history.replace,
+      addRouteLeaveHook: history.listenBeforeLeavingRoute,
+      isActive: history.isActive,
+      createHref: history.createHref,
+      go: history.go,
+      goBack: history.goBack,
+      goForward: history.goForward
     }
     const contextExport = { history, location, router }
     if (__DEV__)

--- a/modules/__tests__/RouterContext-test.js
+++ b/modules/__tests__/RouterContext-test.js
@@ -96,6 +96,62 @@ describe('RouterContext', () => {
         done()
       })
     })
+
+    it('proxies calls to `createHref` to `props.history`', (done) => {
+      const args = [ 1, 2, 3 ]
+      const retVal = function () {}
+      history.createHref = (...params) => {
+        expect(params).toEqual(args)
+        return retVal
+      }
+      renderTest(() => {
+        const createHref = context.router.createHref(...args)
+        expect(createHref).toBe(retVal)
+        done()
+      })
+    })
+
+    it('proxies calls to `go` to `props.history`', (done) => {
+      const args = [ 1, 2, 3 ]
+      const retVal = function () {}
+      history.go = (...params) => {
+        expect(params).toEqual(args)
+        return retVal
+      }
+      renderTest(() => {
+        const go = context.router.go(...args)
+        expect(go).toBe(retVal)
+        done()
+      })
+    })
+
+    it('proxies calls to `goBack` to `props.history`', (done) => {
+      const args = [ 1, 2, 3 ]
+      const retVal = function () {}
+      history.goBack = (...params) => {
+        expect(params).toEqual(args)
+        return retVal
+      }
+      renderTest(() => {
+        const goBack = context.router.goBack(...args)
+        expect(goBack).toBe(retVal)
+        done()
+      })
+    })
+
+    it('proxies calls to `goForward` to `props.history`', (done) => {
+      const args = [ 1, 2, 3 ]
+      const retVal = function () {}
+      history.goForward = (...params) => {
+        expect(params).toEqual(args)
+        return retVal
+      }
+      renderTest(() => {
+        const goForward = context.router.goForward(...args)
+        expect(goForward).toBe(retVal)
+        done()
+      })
+    })
   })
 
 })


### PR DESCRIPTION
Also rewrite how `router` is formed to keep it concise.