### PR TITLE
Don't blacklist es7 class properties

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,8 +3,5 @@
   "loose": "all",
   "plugins": [
     "dev-expression"
-  ],
-  "blacklist": [
-    "es7.classProperties"
   ]
 }


### PR DESCRIPTION
Since we're not using ES6 classes, this isn't a problem anymore. Future usage will break IE8, but that's only if we switch back to classes or explicitly want to drop IE8 support (which it seems like we might at some point anyways).