### PR TITLE
RoutingContext should be RouterContext in server test

### DIFF
--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import React, { Component } from 'react'
 import { renderToString } from 'react-dom/server'
 import match from '../match'
-import RouterContext from '../RoutingContext'
+import RouterContext from '../RouterContext'
 import Link from '../Link'
 
 describe('server rendering', function () {


### PR DESCRIPTION
During the rename to RouterContext, the server_Rendering-test.js was only partially updated. It should be importing RouterContext not RoutingContext.