### PR TITLE
tweaked example in NavigatingOutsideOfComponents

### DIFF
--- a/docs/guides/advanced/NavigatingOutsideOfComponents.md
+++ b/docs/guides/advanced/NavigatingOutsideOfComponents.md
@@ -20,7 +20,7 @@ And then import it to render a `<Router>`:
 ```js
 // index.js
 import history from './history'
-render(<Router history={history}/>, el)
+render(<Router history={history} routes={routes}/>, el)
 ```
 
 And now you can use that history object anywhere in your app, maybe in a


### PR DESCRIPTION
This example confused one of my students as it shows a `Router` without the required children/routes. I added routes to make it valid, without making the actual point of the example less obvious (I hope).