### PR TITLE
Explicitly take path instead of location for match

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,7 +24,7 @@
 
 * [Utilities](#utilities)
   * [useRoutes](#useroutescreatehistory)
-  * [match](#matchlocation-cb)
+  * [match](#match-routes-path-options--cb)
   * [createRoutes](#createroutesroutes)
   * [PropTypes](#proptypes)
 
@@ -677,14 +677,16 @@ Returns a new `createHistory` function that may be used to create history object
 - isActive(pathname, query, indexOnly=false)
 
 
-## `match(location, cb)`
+## `match({ routes, path, ...options }, cb)`
 
 This function is to be used for server-side rendering. It matches a set of routes to a location, without rendering, and calls a `callback(error, redirectLocation, renderProps)` when it's done.
 
+The additional `options` are used to create the history. You can specify `basename` to control the base name for URLs, as well as the pair of `parseQueryString` and `stringifyQuery` to control query string parsing and serializing.
+
 The three arguments to the callback function you pass to `match` are:
-* `error`: A Javascript `Error` object if an error occurred, `undefined` otherwise.
-* `redirectLocation`: A [Location](/docs/Glossary.md#location) object if the route is a redirect, `undefined` otherwise.
-* `renderProps`: The props you should pass to the routing context if the route matched, `undefined` otherwise.
+- `error`: A Javascript `Error` object if an error occurred, `undefined` otherwise.
+- `redirectLocation`: A [Location](/docs/Glossary.md#location) object if the route is a redirect, `undefined` otherwise.
+- `renderProps`: The props you should pass to the routing context if the route matched, `undefined` otherwise.
 
 If all three parameters are `undefined`, this means that there was no route found matching the given location.
 

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -230,7 +230,7 @@ A *router* is a [`history`](http://rackt.github.io/history) object (akin to `win
 There are two primary interfaces for computing a router's next [state](#routerstate):
 
 - `history.listen` is to be used in stateful environments (such as web browsers) that need to update the UI over a period of time. This method immediately invokes its `listener` argument once and returns a function that must be called to stop listening for changes
-- `history.match` is a pure asynchronous function that does not update the history's internal state. This makes it ideal for server-side environments where many requests must be handled concurrently
+- `history.match` is a function that does not update the history's internal state. This makes it ideal for server-side environments where many requests must be handled concurrently
 
 ## RouterListener
 

--- a/docs/guides/advanced/ServerRendering.md
+++ b/docs/guides/advanced/ServerRendering.md
@@ -8,7 +8,7 @@ Server rendering is a bit different than in a client because you'll want to:
 
 To facilitate these needs, you drop one level lower than the [`<Router>`](/docs/API.md#Router) API with:  
 
-- [`match`](https://github.com/rackt/react-router/blob/master/docs/API.md#matchlocation-cb) to match the routes to a location without rendering
+- [`match`](/docs/API.md#match-routes-path-options--cb) to match the routes to a location without rendering
 - `RouterContext` for synchronous rendering of route components
 
 It looks something like this with an imaginary JavaScript server:
@@ -21,7 +21,7 @@ import routes from './routes'
 serve((req, res) => {
   // Note that req.url here should be the full URL path from
   // the original request, including the query string.
-  match({ routes, location: req.url }, (error, redirectLocation, renderProps) => {
+  match({ routes, path: req.url }, (error, redirectLocation, renderProps) => {
     if (error) {
       res.status(500).send(error.message)
     } else if (redirectLocation) {

--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -66,7 +66,7 @@ describe('server rendering', function () {
   }
 
   it('works', function (done) {
-    match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
+    match({ routes, path: '/dashboard' }, function (error, redirectLocation, renderProps) {
       const string = renderToString(
         <RouterContext {...renderProps} />
       )
@@ -76,7 +76,7 @@ describe('server rendering', function () {
   })
 
   it('renders active Links as active', function (done) {
-    match({ routes, location: '/about' }, function (error, redirectLocation, renderProps) {
+    match({ routes, path: '/about' }, function (error, redirectLocation, renderProps) {
       const string = renderToString(
         <RouterContext {...renderProps} />
       )
@@ -87,7 +87,7 @@ describe('server rendering', function () {
   })
 
   it('sends the redirect location', function (done) {
-    match({ routes, location: '/company' }, function (error, redirectLocation) {
+    match({ routes, path: '/company' }, function (error, redirectLocation) {
       expect(redirectLocation).toExist()
       expect(redirectLocation.pathname).toEqual('/about')
       expect(redirectLocation.search).toEqual('')
@@ -98,10 +98,33 @@ describe('server rendering', function () {
   })
 
   it('sends null values when no routes match', function (done) {
-    match({ routes, location: '/no-match' }, function (error, redirectLocation, state) {
+    match({ routes, path: '/no-match' }, function (error, redirectLocation, state) {
       expect(error).toNotExist()
       expect(redirectLocation).toNotExist()
       expect(state).toNotExist()
+      done()
+    })
+  })
+
+  it('works with deprecated location string', function (done) {
+    match({ routes, location: '/dashboard' }, function (error, redirectLocation, renderProps) {
+      const string = renderToString(
+        <RouterContext {...renderProps} />
+      )
+      expect(string).toMatch(/The Dashboard/)
+      done()
+    })
+  })
+
+  it('works with deprecated location object', function (done) {
+    // Poor man's history.createLocation.
+    const location = { pathname: '/dashboard' }
+
+    match({ routes, location }, function (error, redirectLocation, renderProps) {
+      const string = renderToString(
+        <RouterContext {...renderProps} />
+      )
+      expect(string).toMatch(/The Dashboard/)
       done()
     })
   })

--- a/modules/match.js
+++ b/modules/match.js
@@ -1,4 +1,5 @@
 import invariant from 'invariant'
+import warning from 'warning'
 import createMemoryHistory from 'history/lib/createMemoryHistory'
 import useBasename from 'history/lib/useBasename'
 import { createRoutes } from './RouteUtils'
@@ -17,26 +18,30 @@ const createHistory = useRoutes(useBasename(createMemoryHistory))
  */
 function match({
   routes,
+  path,
   location,
-  parseQueryString,
-  stringifyQuery,
-  basename
+  ...options
 }, callback) {
   invariant(
-    location,
-    'match needs a location'
+    path || location,
+    'match needs a path or location'
   )
 
   const history = createHistory({
     routes: createRoutes(routes),
-    parseQueryString,
-    stringifyQuery,
-    basename
+    ...options
   })
 
-  // Allow match({ location: '/the/path', ... })
-  if (typeof location === 'string')
+  warning(
+    location == null,
+    '`match({ location, ...options })` is deprecated; use `match({ path, ...options })` instead'
+  )
+
+  if (path) {
+    location = history.createLocation(path)
+  } else if (typeof location === 'string') {
     location = history.createLocation(location)
+  }
 
   history.match(location, function (error, redirectLocation, nextState) {
     callback(error, redirectLocation, nextState && { ...nextState, history })


### PR DESCRIPTION
I updated the docs here, but not `CHANGES` because we need to comprehensively update them ahead of an interim release.

- API docs on this were out of date.
- It's almost never useful to try to call `createLocation` yourself to make a location object; it's almost always less buggy and easier to just pass in the `path`.
- This is forward-compatible with e.g. updating the `history.createLocation` API to take a location descriptor (rather than a list of args). (but I don't think there's a good reason to encourage users to pass in a location descriptor here)