### PR TITLE
Render user information when under user route

### DIFF
--- a/examples/active-links/app.js
+++ b/examples/active-links/app.js
@@ -44,6 +44,7 @@ class Users extends React.Component {
     return (
       <div>
         <h2>Users</h2>
+        {this.props.children}
       </div>
     )
   }


### PR DESCRIPTION
I find that when it match the route "/users/ryan", it should show the user's id, but it won't.
I think the "Users" should render its children node, so I add some code to achieve this.