### PR TITLE
Updates tab example to allow for IndexLink as appropriate.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -594,19 +594,22 @@ React.createClass({
 Let's say you are using bootstrap and want to get `active` on those `li` tags for the Tabs:
 
 ```js
-import { Link, History } from 'react-router'
+import { Link, IndexLink, History } from 'react-router'
 
 const Tab = React.createClass({
   mixins: [ History ],
   render() {
-    let isActive = this.history.isActive(this.props.to, this.props.query)
-    let className = isActive ? 'active' : ''
-    return <li className={className}><Link {...this.props}/></li>
+    const isActive = this.history.isActive(this.props.to, this.props.query, this.props.indexLink)
+    const className = isActive ? 'active' : ''
+    const LinkElement = this.props.indexLink ? IndexLink : Link;
+    return <li className={className}><LinkElement {...this.props}/></li>
   }
 })
 
-// use it just like <Link/>, and you'll get an anchor wrapped in an `li`
+// use it just like <Link/> or <IndexLink/>, and you'll get an anchor wrapped in an `li`
 // with an automatic `active` class on both.
+<Tab to="/" indexLink>Home</Tab>
+<Tab to="about">About</Tab>
 <Tab href="foo">Foo</Tab>
 ```
 


### PR DESCRIPTION
The Tab example was really helpful to address what I think is a very common case (following bootstrap's navigation markup). Since it's likely that the developer would also need to use IndexLink, I just added a couple tweaks here to allow for it. Also, I believe it's preferable to use `const` over `let` when a variable is not meant to change. So I switched a couple of declarations.