### PR TITLE
simplify the Tab example a bit

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -594,21 +594,21 @@ React.createClass({
 Let's say you are using bootstrap and want to get `active` on those `li` tags for the Tabs:
 
 ```js
-import { Link, IndexLink, History } from 'react-router'
+import { Link, History } from 'react-router'
 
 const Tab = React.createClass({
   mixins: [ History ],
   render() {
-    const isActive = this.history.isActive(this.props.to, this.props.query, this.props.indexLink)
+    const isActive = this.history.isActive(this.props.to, this.props.query, this.props.onlyActiveOnIndex)
     const className = isActive ? 'active' : ''
-    const LinkElement = this.props.indexLink ? IndexLink : Link;
-    return <li className={className}><LinkElement {...this.props}/></li>
+    return <li className={className}><Link {...this.props}/></li>
   }
 })
 
-// use it just like <Link/> or <IndexLink/>, and you'll get an anchor wrapped in an `li`
-// with an automatic `active` class on both.
-<Tab to="/" indexLink>Home</Tab>
+// Use it just like <Link/>, and you'll get an anchor wrapped in an `li` with
+// an automatic `active` class on both when appropriate. Add `onlyActiveOnIndex`
+// to trigger <IndexLink/> behavior.
+<Tab to="/" onlyActiveOnIndex>Home</Tab>
 <Tab to="about">About</Tab>
 <Tab href="foo">Foo</Tab>
 ```


### PR DESCRIPTION
We can avoid the use of <IndexLink/> entirely, since it's just a simple wrapper around <Link/> that adds a single prop.

See some discussion in #2692.