### PR TITLE
Switch back to a caret range for history

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ after_success:
 branches:
   only:
   - master
+  - 1.0.x

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -289,7 +289,7 @@ describe('A <Link>', function () {
       }
 
       const history = createHistory('/')
-      const spy = spyOn(history, 'pushState').andCallThrough()
+      const spy = spyOn(history, 'push').andCallThrough()
 
       const steps = [
         function () {
@@ -297,7 +297,13 @@ describe('A <Link>', function () {
         },
         function () {
           expect(node.innerHTML).toMatch(/Hello/)
-          expect(spy).toHaveBeenCalledWith({ you: 'doing?' }, { pathname: '/hello', search: '?how=are', hash: '#world' })
+          expect(spy).toHaveBeenCalled()
+
+          const { location } = this.state
+          expect(location.pathname).toEqual('/hello')
+          expect(location.search).toEqual('?how=are')
+          expect(location.hash).toEqual('#world')
+          expect(location.state).toEqual({ you: 'doing?' })
         }
       ]
 

--- a/modules/__tests__/isActive-test.js
+++ b/modules/__tests__/isActive-test.js
@@ -390,7 +390,7 @@ describe('isActive', function () {
     describe('with query that does match', function () {
       it('is active', function (done) {
         render((
-          <Router history={createHistory('/home?foo[]=bar&foo[]=bar1&foo[]=bar2')}>
+          <Router history={createHistory('/home?foo=bar&foo=bar1&foo=bar2')}>
             <Route path="/" />
             <Route path="/home" />
           </Router>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "warning": "^2.0.0"
   },
   "peerDependencies": {
-    "history": "1.13.x"
+    "history": "^1.16.0"
   },
   "devDependencies": {
     "babel": "^5.4.7",


### PR DESCRIPTION
This should be published as `1.0.3`. Should fix both the warnings from `history` (removed in `1.16.0`) and any errors about unmet peerDependencies.

Also, note this is on the `1.0.x` branch.