### PR TITLE
Describe case when <RouteHandler {...this.props}/>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -429,12 +429,18 @@ those props are supplied via this approach. In these cases, you should not
 specify `isRequired` for those props. For more details, see
 [facebook/react#4494](https://github.com/facebook/react/issues/4494#issuecomment-125068868).
 
-Caveat: you can no longer do the following as it will overwrite `this.props.children`
-of the child component breaking the chain and causing recurrsion.
+Note spreading `this.props` will overwrite `this.props.children` of the child 
+component breaking the chain and causing recurrsion.
 
 ```js
 // v0.13.x
 <RouteHandler {...this.props}/>
+
+// v1.0
+// you must specify all the props your child needs or remove this.props.children before the spread
+const props = {...this.props}
+delete props.children;
+{React.cloneElement(this.props.children, {...props})}
 ```
 ### Navigation Mixin
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -430,7 +430,7 @@ specify `isRequired` for those props. For more details, see
 [facebook/react#4494](https://github.com/facebook/react/issues/4494#issuecomment-125068868).
 
 Note spreading `this.props` will overwrite `this.props.children` of the child 
-component breaking the chain and causing recurrsion.
+component breaking the chain and causing recurrsion. For more details, see [rackt/react-router#2554](https://github.com/rackt/react-router/issues/2554)
 
 ```js
 // v0.13.x

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -429,6 +429,13 @@ those props are supplied via this approach. In these cases, you should not
 specify `isRequired` for those props. For more details, see
 [facebook/react#4494](https://github.com/facebook/react/issues/4494#issuecomment-125068868).
 
+Caveat: you can no longer do the following as it will overwrite `this.props.children`
+of the child component breaking the chain and causing recurrsion.
+
+```js
+// v0.13.x
+<RouteHandler {...this.props}/>
+```
 ### Navigation Mixin
 
 If you were using the `Navigation` mixin, use the `History` mixin instead.


### PR DESCRIPTION
I recently upgraded to 1.0 and got stuck when the app was going into an stack overflow error because i was spreading this props to this.props.children. 
It would have been nice to have a bit of a heads up in the changelog as the error is not obvious.  