### PR TITLE
Remove shared root example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -16,7 +16,6 @@
 <li><a href="pinterest">Pinterest-style UI (location.state)</a></li>
 <li><a href="nested-animations">Nested Animations</a></li>
 <li><a href="query-params">Query Params</a></li>
-<li><a href="shared-root">Shared Root</a></li>
 <li><a href="sidebar">Sidebar</a></li>
 <li><a href="transitions">Transitions</a></li>
 </ul>


### PR DESCRIPTION
It doesn't link to anything,
`Cannot GET /shared-root`