### PR TITLE
Displays component name instead of component title in breadcrumb example

### DIFF
--- a/examples/breadcrumbs/app.js
+++ b/examples/breadcrumbs/app.js
@@ -23,7 +23,7 @@ class App extends React.Component {
                   onlyActiveOnIndex={true}
                   activeClassName="breadcrumb-active"
                   to={item.path || ''}>
-                  {item.component.title}
+                  {item.component.name}
                 </Link>
                 {(index + 1) < depth && '\u2192'}
               </li>


### PR DESCRIPTION
I couldn't get the `{item.component.title} ` to display in the breadcrumb example.  I changed to `{item.component.name} ` and the names displayed.

I am not sure if I caught a typo, or if I am doing something incorrect, but I though I would send it along.