### PR TITLE
Add activeTitle on Link

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -111,6 +111,9 @@ The className a `<Link>` receives when its route is active. No active class by d
 ##### `activeStyle`
 The styles to apply to the link element when its route is active.
 
+##### `activeTitle`
+The title to apply to the link element when its route is active.
+
 ##### `onClick(e)`
 A custom handler for the click event. Works just like a handler on an `<a>` tag - calling `e.preventDefault()` will prevent the transition from firing, while `e.stopPropagation()` will prevent the event from bubbling.
 

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -103,7 +103,7 @@ const Link = React.createClass({
   },
 
   render() {
-    const { to, query, hash, state, activeClassName, activeStyle, onlyActiveOnIndex, ...props } = this.props
+    const { to, query, hash, state, activeClassName, activeStyle, activeTitle, onlyActiveOnIndex, ...props } = this.props
     warning(
       !(query || hash || state),
       'the `query`, `hash`, and `state` props on `<Link>` are deprecated; use a location descriptor instead'
@@ -125,6 +125,11 @@ const Link = React.createClass({
           if (activeStyle)
             props.style = { ...props.style, ...activeStyle }
         }
+      }
+
+      if (activeTitle) {
+        if (router.isActive(loc, onlyActiveOnIndex))
+          props.title = activeTitle
       }
     }
 

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -266,6 +266,43 @@ describe('A <Link>', function () {
         </Router>
       ), node, execNextStep)
     })
+
+    it('has its activeTitle', function (done) {
+      class LinkWrapper extends Component {
+        render() {
+          return (
+            <div>
+              <Link to="/hello" title="Hello" activeTitle="Hello - current page">Link</Link>
+              {this.props.children}
+            </div>
+          )
+        }
+      }
+
+      let a
+      const history = createHistory('/goodbye')
+      const steps = [
+        function () {
+          a = node.querySelector('a')
+          expect(a.title).toEqual('Hello')
+          history.push('/hello')
+        },
+        function () {
+          expect(a.title).toEqual('Hello - current page')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={history} onUpdate={execNextStep}>
+          <Route path="/" component={LinkWrapper}>
+            <Route path="goodbye" component={Goodbye} />
+            <Route path="hello" component={Hello} />
+          </Route>
+        </Router>
+      ), node, execNextStep)
+    })
   })
 
   describe('when route changes', function () {


### PR DESCRIPTION
It is a common need when building accessible interfaces that a different link title should be set depending on the context.

For example, given this set of links in a main menu:

```html
<a href="/" title="Home">Home</a>
<a href="/about" title="About">About</a>
```

When the current page is `/about`, then the titles could change to:

```html
<a href="/" title="Home">Home</a>
<a href="/about" title="About (current page)">About</a>
```

That way, someone using a screen reader can know which page is currently displayed.

This pull request adds a way to set a custom title on Link components when their routes are active.