### PR TITLE
Revert "Remove history npm workaround"

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,4 +44,14 @@ git push origin latest -f
 
 node scripts/build.js
 
+# This is a workaround for a nasty npm bug. :'(
+# First, we need to uninstall the history package so
+# it's not included in the react-router npm package.
+# https://github.com/rackt/react-router/issues/2195
+# https://github.com/npm/npm/issues/9894
+rm -rf node_modules/history
+
 npm publish
+
+# And then re-install it after we publish.
+npm install history


### PR DESCRIPTION
Reverts rackt/react-router#2756

fml

npm3 vendored in the file from fstream-npm, so the release notes about how this was fixed on npm3 were just wrong. Sorry.