### PR TITLE
Export createMemoryHistory

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -25,5 +25,6 @@ export useRouterHistory from './useRouterHistory'
 /* histories */
 export browserHistory from './browserHistory'
 export hashHistory from './hashHistory'
+export createMemoryHistory from './createMemoryHistory'
 
 export default from './Router'


### PR DESCRIPTION
[`createMemoryHistory` is documented](https://github.com/rackt/react-router/blob/54ec6a81d759bb78b17687d6b0689b0fc6e49873/docs/guides/basics/Histories.md#creatememoryhistory) as being importable from the React Router package but isn't being exported in 2.0.0-rc3