### PR TITLE
Upgrade Guide Correction for Custom Histories

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -77,9 +77,10 @@ const history = createHashHistory({ queryKey: false })
 <Router history={history}/>
 
 // v2.0.0
-import { useRouterHistory, hashHistory } from 'react-router'
+import { Router, useRouterHistory } from 'react-router'
+import { createHashHistory } from 'history'
 // useRouterHistory creates a composable higher-order function
-const appHistory = useRouterHistory(hashHistory)({ queryKey: false })
+const appHistory = useRouterHistory(createHashHistory)({ queryKey: false })
 <Router history={appHistory}/>
 ```
 


### PR DESCRIPTION
Since `hashHistory` is a singleton and not a function, it can't be used with `useRouterHistory`.

I've updated the guide to a working guide, but maybe `createHashHistory` should also be exported by `react-router`, so the user doesn't need `history` as an explicit dependency for this case? Or even better: the exported `createHashHistory` could be used without `useRouterHistory` …