### PR TITLE
Small fix for the transitions example for 2.0

### DIFF
--- a/examples/transitions/app.js
+++ b/examples/transitions/app.js
@@ -23,9 +23,12 @@ const Dashboard = React.createClass({
 })
 
 const Form = React.createClass({
+  contextTypes: {
+    router: React.PropTypes.object.isRequired
+  },
 
   componentWillMount() {
-    this.props.router.setRouteLeaveHook(
+    this.context.router.setRouteLeaveHook(
       this.props.route,
       this.routerWillLeave
     )


### PR DESCRIPTION
Added contextTypes(router) to the Form component of the transitions example and also change this.props.router to this.context.router to get the setRouteLeaveHook working.