### PR TITLE
Fix "Confirming Navigation" link

### DIFF
--- a/upgrade-guides/v1.0.0.md
+++ b/upgrade-guides/v1.0.0.md
@@ -362,7 +362,7 @@ var Home = React.createClass({
 ```
 
 To cancel a "transition from", please refer to the
-[Confirming Navigation](docs/guides/advanced/ConfirmingNavigation.md) guide.
+[Confirming Navigation](/docs/guides/advanced/ConfirmingNavigation.md) guide.
 
 ### We'll keep updating this
 


### PR DESCRIPTION
Noticed this while reading through the docs.  I think it just needed a leading slash.

Test Plan:
- Previewed and opened the link, seemed to work.