### PR TITLE
Fix link to context.router in API documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@
   - [Link](#link)
   - [IndexLink](#indexlink)
   - [RouterContext](#routercontext)
-    - [context.router](#context-router)
+    - [context.router](#contextrouter)
   - RoutingContext (deprecated, use `RouterContext`)
 
 * [Configuration Components](#configuration-components)


### PR DESCRIPTION
The generated ID is `contextrouter`: https://github.com/rackt/react-router/blob/master/docs/API.md#contextrouter