### PR TITLE
Updates docs for custom query parsing in V2

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -264,9 +264,10 @@ router.isActive({ pathname, query }, indexOnly)
 />
 
 // v2.0.0
-import { useRouterHistory, browserHistory } from 'react-router'
+import { useRouterHistory } from 'react-router'
+import createBrowserHistory from 'history/lib/createBrowserHistory'
 
-const createAppHistory = useRouterHistory(browserHistory)
+const createAppHistory = useRouterHistory(createBrowserHistory)
 
 const appHistory = createAppHistory({
   parseQueryString: parse,


### PR DESCRIPTION
Small update to the V2 upgrade guid.  In V2, custom query parsing needs to be done via custom histories:  https://github.com/rackt/react-router/blob/master/upgrade-guides/v2.0.0.md#using-custom-histories

Fixes #2842