### PR TITLE
setRouteLeaveHook over setLeaveHook

### DIFF
--- a/docs/guides/advanced/ConfirmingNavigation.md
+++ b/docs/guides/advanced/ConfirmingNavigation.md
@@ -10,7 +10,7 @@ const Home = React.createClass({
   },
 
   componentDidMount() {
-    this.context.router.setLeaveHook(this.props.route, this.routerWillLeave)
+    this.context.router.setRouteLeaveHook(this.props.route, this.routerWillLeave)
   },
 
   routerWillLeave(nextLocation) {


### PR DESCRIPTION
I think in rc4 the API is `setRouteLeaveHook` instead of `setLeaveHook` ?