### PR TITLE
Add link to details explaining what is '_k' in v1.0.0 Upgrade Guide

### DIFF
--- a/upgrade-guides/v1.0.0.md
+++ b/upgrade-guides/v1.0.0.md
@@ -66,7 +66,7 @@ let history = createBrowserHistory()
 render(<Router history={history}>{routes}</Router>, el)
 ```
 
-If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a querystring entry not defined by yourself will start appearing in your URLs called `_k`. An example of how it looks is this: `?_k=umhx1s`
+If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a querystring entry not defined by yourself will start appearing in your URLs called `_k`. An example of how it looks is this: `?_k=umhx1s`. You can read more about it [here](/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url).
 
 This is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
 


### PR DESCRIPTION
While reading about **v1.0.0 Upgrade Guide**, I did not understand why
shall I see that `_k` in the URL. After reading about it in
`Docs -> Guides -> Basics -> Histories`, I understood it.

Added a link in the **v1.0.0 Upgrade Guide** to reduce the efforts for
people looking for details about it.