### PR TITLE
Added confirmation popup to example

### DIFF
--- a/docs/guides/advanced/ConfirmingNavigation.md
+++ b/docs/guides/advanced/ConfirmingNavigation.md
@@ -17,7 +17,7 @@ const Home = React.createClass({
     // return false to prevent a transition w/o prompting the user,
     // or return a string to allow the user to decide:
     if (!this.state.isSaved)
-      return 'Your work is not saved! Are you sure you want to leave?'
+      return confirm('Your work is not saved! Are you sure you want to leave?')
   },
 
   // ...


### PR DESCRIPTION
In the original version this would always return a string (true) when the this.state.isSaved was false, giving the user no choice but to save the content if he wanted to leave. This way it will display a confirmation dialog and let the user decide if he wants to drop the work or not. Just for example sake :)