### PR TITLE
Do not include histories in index.js

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -46,7 +46,7 @@ Alias for `children`.
 The history the router should listen to. Typically `browserHistory` or `hashHistory`.
 
 ```js
-import { browserHistory } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 ReactDOM.render(<Router history={browserHistory}/>, el)
 ```
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -106,7 +106,8 @@ import React from 'react'
 import { render } from 'react-dom'
 
 // First we import some modules...
-import { Router, Route, IndexRoute, Link, hashHistory } from 'react-router'
+import { Router, Route, IndexRoute, Link } from 'react-router'
+import hashHistory from 'react-router/lib/hashHistory'
 
 // Then we delete a bunch of code from App and
 // add some <Link> elements...

--- a/docs/guides/advanced/NavigatingOutsideOfComponents.md
+++ b/docs/guides/advanced/NavigatingOutsideOfComponents.md
@@ -4,13 +4,14 @@ While you can use `this.context.router` to navigate around, many apps want to be
 
 ```js
 // your main file that renders a Router
-import { Router, browserHistory } from 'react-router'
+import { Router } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 import routes from './app/routes'
 render(<Router history={browserHistory} routes={routes}/>, el)
 ```
 
 ```js
 // somewhere like a redux/flux action file:
-import { browserHistory } from './react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 browserHistory.push('/some/path')
 ```

--- a/docs/guides/basics/Histories.md
+++ b/docs/guides/basics/Histories.md
@@ -13,11 +13,11 @@ consumption with React Router.
 - [`browserHistory`](#browserhistory)
 - [`createMemoryHistory`](#creatememoryhistory)
 
-You import them from the React Router package:
+You import them from `react-router/lib` under the React Router package:
 
 ```js
 // JavaScript module import
-import { browserHistory } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 ```
 
 Then pass them into your `<Router>`:
@@ -103,7 +103,8 @@ app, the client entry point would look like:
 ```js
 import React from 'react'
 import { render } from 'react-dom'
-import { browserHistory, Router, Route, IndexRoute } from 'react-router'
+import { Router, Route, IndexRoute } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 
 import App from '../components/App'
 import Home from '../components/Home'

--- a/modules/index.js
+++ b/modules/index.js
@@ -23,10 +23,3 @@ export PropTypes from './PropTypes'
 export match from './match'
 export useRouterHistory from './useRouterHistory'
 export { formatPattern } from './PatternUtils'
-
-/* histories */
-export browserHistory from './browserHistory'
-export hashHistory from './hashHistory'
-export createMemoryHistory from './createMemoryHistory'
-
-export default from './Router'

--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -38,6 +38,8 @@ A codemod is much like Babel, but instead of converting your ES2015 code to ES5 
 
 We now include singleton `history` instances for you to use in the router. They are `hashHistory` (hash-based URLs) and `browserHistory` (HTML5 pushState "pretty" URLs). They include any needed history wrappers (such as `useQueries`) so you don't have to write as much boilerplate as before.
 
+These singletons need to be imported from `react-router/lib` rather than the top-level `react-router` import. This allows us to minimize bundle size when those histories are not used. 
+
 Another big change because of this is `history` is now a normal dependency. You no longer have to install and maintain `history` separately. Batteries included!
 
 ### No Default History
@@ -50,13 +52,13 @@ Another big change because of this is `history` is now a normal dependency. You 
 
 // v2.0.0
 // hash history
-import { hashHistory } from 'react-router'
+import hashHistory from 'react-router/lib/hashHistory'
 <Router history={hashHistory} />
 ```
 
 ### Using Browser (HTML5 pushState) History
 
-As already mentioned, you now use the singleton `browserHistory` exported from `react-router`.
+As already mentioned, you now use the singleton `browserHistory` available in `react-router`.
 
 ```js
 // v1.x
@@ -64,7 +66,7 @@ import createBrowserHistory from 'history/lib/createBrowserHistory'
 <Router history={createBrowserHistory()} />
 
 // v2.0.0
-import { browserHistory } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 <Router history={browserHistory} />
 ```
 
@@ -221,7 +223,7 @@ const DeepComponent = React.createClass({
 }
 
 // 2) Use the singleton history you are using when the router was rendered,
-import { browserHistory } from 'react-router'
+import browserHistory from 'react-router/lib/browserHistory'
 const DeepComponent = React.createClass({
   someHandler() {
     browserHistory.push(...)


### PR DESCRIPTION
Closes https://github.com/rackt/react-router/issues/2853

Well... mostly. Via `createRouterHistory` and `match`, we always end up pulling in `useQueries` and `useBasename`, which is not entirely ideal. That's for https://github.com/rackt/react-router/issues/2814, though.

This also drops the top-level default export of `Router`, which was undocumented and inconsistent and shouldn't really be used.