### PR TITLE
Option to use router.replace in Link

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -122,6 +122,9 @@ The styles to apply to the link element when its route is active.
 ##### `onClick(e)`
 A custom handler for the click event. Works just like a handler on an `<a>` tag - calling `e.preventDefault()` will prevent the transition from firing, while `e.stopPropagation()` will prevent the event from bubbling.
 
+#### `useReplace`
+If true the Link will call `router.replace` instead of `router.push`.
+
 ##### *others*
 You can also pass props you'd like to be on the `<a>` such as a `title`, `id`, `className`, etc.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -122,7 +122,7 @@ The styles to apply to the link element when its route is active.
 ##### `onClick(e)`
 A custom handler for the click event. Works just like a handler on an `<a>` tag - calling `e.preventDefault()` will prevent the transition from firing, while `e.stopPropagation()` will prevent the event from bubbling.
 
-#### `useReplace`
+##### `useReplace`
 If true the Link will call `router.replace` instead of `router.push`.
 
 ##### *others*

--- a/modules/Link.js
+++ b/modules/Link.js
@@ -59,6 +59,7 @@ const Link = React.createClass({
     activeStyle: object,
     activeClassName: string,
     onlyActiveOnIndex: bool.isRequired,
+    useReplace: bool.isRequired,
     onClick: func
   },
 
@@ -66,7 +67,8 @@ const Link = React.createClass({
     return {
       onlyActiveOnIndex: false,
       className: '',
-      style: {}
+      style: {},
+      useReplace: false
     }
   },
 
@@ -94,11 +96,15 @@ const Link = React.createClass({
     event.preventDefault()
 
     if (allowTransition) {
-      let { state, to, query, hash } = this.props
+      let { state, to, query, hash, useReplace } = this.props
 
       const location = createLocationDescriptor({ to, query, hash, state })
 
-      this.context.router.push(location)
+      if (useReplace) {
+        this.context.router.replace(location)
+      } else {
+        this.context.router.push(location)
+      }
     }
   },
 

--- a/modules/__tests__/Link-test.js
+++ b/modules/__tests__/Link-test.js
@@ -409,6 +409,41 @@ describe('A <Link>', function () {
         </Router>
       ), node, execNextStep)
     })
+
+    it('uses router.replace if useReplace is on', function (done) {
+      class LinkWrapper extends Component {
+        render() {
+          return <Link to="/hello" useReplace>Link</Link>
+        }
+      }
+
+      const history = createHistory('/')
+      const pushSpy = spyOn(history, 'push').andCallThrough()
+      const replaceSpy = spyOn(history, 'replace').andCallThrough()
+
+      const steps = [
+        function () {
+          click(node.querySelector('a'), { button: 0 })
+        },
+        function () {
+          expect(node.innerHTML).toMatch(/Hello/)
+          expect(replaceSpy).toHaveBeenCalled()
+          expect(pushSpy).toNotHaveBeenCalled()
+
+          const { location } = this.state
+          expect(location.pathname).toEqual('/hello')
+        }
+      ]
+
+      const execNextStep = execSteps(steps, done)
+
+      render((
+        <Router history={history} onUpdate={execNextStep}>
+          <Route path="/" component={LinkWrapper} />
+          <Route path="/hello" component={Hello} />
+        </Router>
+      ), node, execNextStep)
+    })
   })
 
 })


### PR DESCRIPTION
This is especially handy if you only need to update the query in a link. 

I try to keep as much state as possible in the url, I want to do this too for a small image gallery. Except it is quite inconvenient if you have to press back 7 times to go to the previous page after you watched 7 images.