### PR TITLE
Transition hooks swallow basename (failing test)

### DIFF
--- a/modules/__tests__/useRouterHistory-test.js
+++ b/modules/__tests__/useRouterHistory-test.js
@@ -1,7 +1,12 @@
 import assert from 'assert'
 import expect from 'expect'
+import React from 'react'
+import { render, unmountComponentAtNode } from 'react-dom'
 import useRouterHistory from '../useRouterHistory'
 import createHistory from 'history/lib/createMemoryHistory'
+import Redirect from '../Redirect'
+import Router from '../Router'
+import Route from '../Route'
 
 describe('useRouterHistory', function () {
   it('adds backwards compatibility flag', function () {
@@ -19,5 +24,41 @@ describe('useRouterHistory', function () {
 
     history.push({ pathname: '/', query: { test: true } })
   })
-})
 
+  describe('when using basename', function () {
+
+    let node
+    beforeEach(function () {
+      node = document.createElement('div')
+    })
+
+    afterEach(function () {
+      unmountComponentAtNode(node)
+    })
+
+    it('should regard basename', function (done) {
+      const pathnames = []
+      const basenames = []
+      const history = useRouterHistory(createHistory)({
+        entries: '/foo/notes/5',
+        basename: '/foo'
+      })
+      history.listen(function (location) {
+        pathnames.push(location.pathname)
+        basenames.push(location.basename)
+      })
+      render((
+        <Router history={history}>
+          <Route path="/messages/:id" />
+          <Redirect from="/notes/:id" to="/messages/:id" />
+        </Router>
+      ), node, function () {
+        expect(pathnames).toEqual([ '/notes/5', '/messages/5' ])
+        expect(basenames).toEqual([ '/foo', '/foo' ])
+        expect(this.state.location.pathname).toEqual('/inbox')
+        expect(this.state.location.basename).toEqual('/foo')
+        done()
+      })
+    })
+  })
+})

--- a/modules/__tests__/useRouterHistory-test.js
+++ b/modules/__tests__/useRouterHistory-test.js
@@ -55,7 +55,7 @@ describe('useRouterHistory', function () {
       ), node, function () {
         expect(pathnames).toEqual([ '/notes/5', '/messages/5' ])
         expect(basenames).toEqual([ '/foo', '/foo' ])
-        expect(this.state.location.pathname).toEqual('/inbox')
+        expect(this.state.location.pathname).toEqual('/messages/5')
         expect(this.state.location.basename).toEqual('/foo')
         done()
       })


### PR DESCRIPTION
When using `basename` and hitting a redirect, the `basename` gets swallowed. I'm not sure if this is the correct place for the failing test, but it illustrates the issue.

After hitting `/redirect-to-inbox`, the basenames array should contain `[ '/foo', '/foo', '/foo' ]`. The last element however is empty: `[ '/foo', '/foo', '' ]`. This results in a wrong path: instead of `/foo/inbox` we get `/inbox`.

I've no idea how to fix this, but I hope the failing test helps!