### PR TITLE
Fix initial routing state after match

### DIFF
--- a/docs/guides/advanced/ServerRendering.md
+++ b/docs/guides/advanced/ServerRendering.md
@@ -44,7 +44,7 @@ For data loading, you can use the `renderProps` argument to build whatever conve
 
 Server rendering works identically when using async routes. However, the client-side rendering needs to be a little different to make sure all of the async behavior has been resolved before the initial render, to avoid a mismatch between the server rendered and client rendered markup.
 
-Instead of rendering
+On the client, instead of rendering
 
 ```js
 render(<Router history={history} routes={routes} />, mountNode)
@@ -53,7 +53,7 @@ render(<Router history={history} routes={routes} />, mountNode)
 You need to do
 
 ```js
-match({ routes, location }, (error, redirectLocation, renderProps) => {
-  render(<Router {...renderProps} history={history} />, mountNode)
+match({ history, routes }, (error, redirectLocation, renderProps) => {
+  render(<Router {...renderProps} />, mountNode)
 })
 ```

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -217,12 +217,12 @@ export default function createTransitionManager(history, routes) {
           unlistenBeforeUnload = history.listenBeforeUnload(beforeUnloadHook)
       }
     } else {
-      warning(
-        false,
-        'adding multiple leave hooks for the same route is deprecated; manage multiple confirmations in your own code instead'
-      )
-
       if (hooks.indexOf(hook) === -1) {
+        warning(
+          false,
+          'adding multiple leave hooks for the same route is deprecated; manage multiple confirmations in your own code instead'
+        )
+
         hooks.push(hook)
       }
     }

--- a/modules/match.js
+++ b/modules/match.js
@@ -47,7 +47,12 @@ function match({ history, routes, location, ...options }, callback) {
     callback(
       error,
       redirectLocation,
-      nextState && { ...nextState, history, router, transitionManager }
+      nextState && {
+        ...nextState,
+        history,
+        router,
+        matchContext: { history, transitionManager, router }
+      }
     )
 
     // Defer removing the listener to here to prevent DOM histories from having


### PR DESCRIPTION
Fixes https://github.com/rackt/react-router/issues/2935

https://github.com/rackt/react-router/pull/2883 was actually busted and had a test that didn't cover what it was supposed to.

~~In an ideal world we'd just use the same `history` and `transitionManager` for `match()` and `<Router>` on the client side, but the deprecation wrapping API messes with that too much, so this might be the best we can do for now.~~