### PR TITLE
Fix initial routing state after match

### DIFF
--- a/docs/guides/advanced/ServerRendering.md
+++ b/docs/guides/advanced/ServerRendering.md
@@ -44,7 +44,7 @@ For data loading, you can use the `renderProps` argument to build whatever conve
 
 Server rendering works identically when using async routes. However, the client-side rendering needs to be a little different to make sure all of the async behavior has been resolved before the initial render, to avoid a mismatch between the server rendered and client rendered markup.
 
-Instead of rendering
+On the client, instead of rendering
 
 ```js
 render(<Router history={history} routes={routes} />, mountNode)
@@ -53,7 +53,7 @@ render(<Router history={history} routes={routes} />, mountNode)
 You need to do
 
 ```js
-match({ routes, location }, (error, redirectLocation, renderProps) => {
-  render(<Router {...renderProps} history={history} />, mountNode)
+match({ history, routes }, (error, redirectLocation, renderProps) => {
+  render(<Router {...renderProps} />, mountNode)
 })
 ```

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -63,36 +63,32 @@ const Router = React.createClass({
   },
 
   componentWillMount() {
-    const { router } = this.props
-    let transitionManager
+    let { router, history, transitionManager } = this.props
 
-    if (router) {
-      // This is coming from match(), and is already wrapped.
-      transitionManager = this.props.transitionManager
+    const { parseQueryString, stringifyQuery } = this.props
+    warning(
+      !(parseQueryString || stringifyQuery),
+      '`parseQueryString` and `stringifyQuery` are deprecated. Please create a custom history. http://tiny.cc/router-customquerystring'
+    )
 
-      this.router = router
-      this.history = this.props.history
-    } else {
-      let { history } = this.props
+    if (isDeprecatedHistory(history)) {
+      history = this.wrapDeprecatedHistory(history)
+    }
+
+    if (!transitionManager) {
       const { routes, children } = this.props
-
-      const { parseQueryString, stringifyQuery } = this.props
-      warning(
-        !(parseQueryString || stringifyQuery),
-        '`parseQueryString` and `stringifyQuery` are deprecated. Please create a custom history. http://tiny.cc/router-customquerystring'
-      )
-
-      if (isDeprecatedHistory(history)) {
-        history = this.wrapDeprecatedHistory(history)
-      }
-
       transitionManager = createTransitionManager(
         history, createRoutes(routes || children)
       )
-
-      this.router = createRouterObject(history, transitionManager)
-      this.history = createRoutingHistory(history, transitionManager)
     }
+
+    if (!router) {
+      router = createRouterObject(history, transitionManager)
+      history = createRoutingHistory(history, transitionManager)
+    }
+
+    this.router = router
+    this.history = history
 
     this._unlisten = transitionManager.listen((error, state) => {
       if (error) {

--- a/modules/Router.js
+++ b/modules/Router.js
@@ -1,6 +1,7 @@
 import createHashHistory from 'history/lib/createHashHistory'
 import useQueries from 'history/lib/useQueries'
 import React from 'react'
+import invariant from 'invariant'
 
 import createTransitionManager from './createTransitionManager'
 import { routes } from './PropTypes'
@@ -71,24 +72,24 @@ const Router = React.createClass({
       '`parseQueryString` and `stringifyQuery` are deprecated. Please create a custom history. http://tiny.cc/router-customquerystring'
     )
 
-    if (isDeprecatedHistory(history)) {
-      history = this.wrapDeprecatedHistory(history)
-    }
+    if (router) {
+      invariant(
+        transitionManager && history,
+        'When providing a `router` prop to Router, you must also provide a `transitionManager` and `history` prop.'
+      )
+    } else {
+      if (isDeprecatedHistory(history)) {
+        history = this.wrapDeprecatedHistory(history)
+      }
 
-    if (!transitionManager) {
       const { routes, children } = this.props
       transitionManager = createTransitionManager(
         history, createRoutes(routes || children)
       )
-    }
 
-    if (!router) {
       router = createRouterObject(history, transitionManager)
       history = createRoutingHistory(history, transitionManager)
     }
-
-    this.router = router
-    this.history = history
 
     this._unlisten = transitionManager.listen((error, state) => {
       if (error) {
@@ -97,6 +98,9 @@ const Router = React.createClass({
         this.setState(state, this.props.onUpdate)
       }
     })
+
+    this.router = router
+    this.history = history
   },
 
   wrapDeprecatedHistory(history) {

--- a/modules/createTransitionManager.js
+++ b/modules/createTransitionManager.js
@@ -217,12 +217,12 @@ export default function createTransitionManager(history, routes) {
           unlistenBeforeUnload = history.listenBeforeUnload(beforeUnloadHook)
       }
     } else {
-      warning(
-        false,
-        'adding multiple leave hooks for the same route is deprecated; manage multiple confirmations in your own code instead'
-      )
-
       if (hooks.indexOf(hook) === -1) {
+        warning(
+          false,
+          'adding multiple leave hooks for the same route is deprecated; manage multiple confirmations in your own code instead'
+        )
+
         hooks.push(hook)
       }
     }


### PR DESCRIPTION
Continuation of #2965

-

#2883 was actually busted and had a test that didn't cover what it was supposed to.

In an ideal world we'd just use the same history and transitionManager for match() and <Router> on the client side, but the deprecation wrapping API messes with that too much, so this might be the best we can do for now.