### PR TITLE
Remove misleading example from upgrade guide

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -84,7 +84,7 @@ const appHistory = useRouterHistory(createHashHistory)({ queryKey: false })
 
 ## Changes to `this.context`
 
-Only an object named `router` is added to context. Accessing `this.context.history`, `this.context.location`, and `this.context.route` are all deprecated. This new object contains the methods available from `history` (such as `push`, `replace`) along with `setRouteLeaveHook`. 
+Only an object named `router` is added to context. Accessing `this.context.history`, `this.context.location`, and `this.context.route` are all deprecated. This new object contains the methods available from `history` (such as `push`, `replace`) along with `setRouteLeaveHook`.
 
 ### Accessing location
 
@@ -207,22 +207,13 @@ const DeepComponent = React.createClass({
 }
 
 // v2.0.0
-// You have a couple options:
-// 1) Use context.router
+// Use context.router
 const DeepComponent = React.createClass({
   contextTypes: {
     router: React.PropTypes.object.isRequired
   },
   someHandler() {
     this.context.router.push(...)
-  }
-}
-
-// 2) Use the singleton history you are using when the router was rendered,
-import { browserHistory } from 'react-router'
-const DeepComponent = React.createClass({
-  someHandler() {
-    browserHistory.push(...)
   }
 }
 ```


### PR DESCRIPTION
Per discussion in #2991, the second example is a fragile pattern. As @taion mentioned:

> I don't think we really guarantee that you can just split out push like that, instead of calling it via router.push.

`browserHistory` is undefined in non-browser environments, so accessing `browserHistory.push` throws. It also relies on using the same history passed to `Router`, which may (conditionally) change.

Let me know if you'd prefer adding a warning over removing the example entirely.