### PR TITLE
docs(example): fix module name

### DIFF
--- a/docs/guides/advanced/NavigatingOutsideOfComponents.md
+++ b/docs/guides/advanced/NavigatingOutsideOfComponents.md
@@ -11,6 +11,6 @@ render(<Router history={browserHistory} routes={routes}/>, el)
 
 ```js
 // somewhere like a redux/flux action file:
-import { browserHistory } from './react-router'
+import { browserHistory } from 'react-router'
 browserHistory.push('/some/path')
 ```


### PR DESCRIPTION
This should import from the base module.