### PR TITLE
Update v2.0.0 Upgrade Documentation - stringifyQueryString -> stringifyQuery

### DIFF
--- a/upgrade-guides/v2.0.0.md
+++ b/upgrade-guides/v2.0.0.md
@@ -272,7 +272,7 @@ const createAppHistory = useRouterHistory(createBrowserHistory)
 
 const appHistory = createAppHistory({
   parseQueryString: parse,
-  stringifyQueryString: stringify
+  stringifyQuery: stringify
 })
 
 <Router history={appHistory}/>


### PR DESCRIPTION
The documentation previously said the hook for a customized query stringification was `stringifyQueryString` but key should actually be `stringifyQuery` which can be seen in the History module here:
https://github.com/rackt/history/blob/master/modules/useQueries.js#L32