### PR TITLE
update query param Link to

### DIFF
--- a/examples/active-links/app.js
+++ b/examples/active-links/app.js
@@ -17,7 +17,7 @@ class App extends React.Component {
           <li><IndexLink to="/users"      activeStyle={ACTIVE}>/users IndexLink</IndexLink></li>
 
           <li><Link      to="/users/ryan" activeStyle={ACTIVE}>/users/ryan</Link></li>
-          <li><Link      to={{ pathname: '/users/ryan', query: { foo: 'bar' } }}
+          <li><Link      to="/users/ryan" query={{ foo: 'bar' }}
                                           activeStyle={ACTIVE}>/users/ryan?foo=bar</Link></li>
 
           <li><Link      to="/about"      activeStyle={ACTIVE}>/about</Link></li>


### PR DESCRIPTION
Updated the query param syntax on the `active-links` example. When trying the example, couldn't get the code to compile at first in the example, and noticed the query param syntax had changed, so updated it, and am making this PR.