### PR TITLE
Add back basename support in match()

### DIFF
--- a/modules/__tests__/serverRendering-test.js
+++ b/modules/__tests__/serverRendering-test.js
@@ -152,6 +152,16 @@ describe('server rendering', function () {
     })
   })
 
+  it('accepts a basename option', function (done) {
+    match({ routes, location: '/dashboard', basename: '/nasebame' }, function (error, redirectLocation, renderProps) {
+      const string = renderToString(
+        <RouterContext {...renderProps} />
+      )
+      expect(string).toMatch(/\/nasebame/)
+      done()
+    })
+  })
+
   describe('server/client consistency', function () {
     // Just render to static markup here to avoid having to normalize markup.
 

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -1,4 +1,5 @@
 import useQueries from 'history/lib/useQueries'
+import useBasename from 'history/lib/useBasename'
 import baseCreateMemoryHistory from 'history/lib/createMemoryHistory'
 
 export default function createMemoryHistory(options) {
@@ -7,7 +8,7 @@ export default function createMemoryHistory(options) {
   // `useQueries` doesn't understand the signature
   const memoryHistory = baseCreateMemoryHistory(options)
   const createHistory = () => memoryHistory
-  const history = useQueries(createHistory)(options)
+  const history = useQueries(useBasename(createHistory))(options)
   history.__v2_compatible__ = true
   return history
 }


### PR DESCRIPTION
Fixes #3003

Looks like we broke this inadvertently back in #2743. Specifically, we did so here: https://github.com/rackt/react-router/pull/2743#discussion_r48084686 

Users should use a custom history from now on, but this maintains BC with 1.0.