### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -315,7 +315,7 @@ code-splitting.
 ```
 
 ##### `children`
-Routes can be nested, `this.props.children` will contain the element created from the child route component. Please refer to the [Route Configuration](/docs/guides/basics/RouteConfiguration.md) since this is a very critical part of the router's design.
+Routes can be nested, `this.props.children` will contain the element created from the child route component. Please refer to the [Route Configuration](/docs/guides/RouteConfiguration.md) since this is a very critical part of the router's design.
 
 ##### `onEnter(nextState, replace, callback?)`
 Called when a route is about to be entered. It provides the next router state and a function to redirect to another path. `this` will be the route instance that triggered the hook.
@@ -377,7 +377,7 @@ let myRoute = {
 ```
 
 ##### `indexRoute`
-The [index route](/docs/guides/basics/IndexRoutes.md). This is the same as specifying an `<IndexRoute>` child when using JSX route configs.
+The [index route](/docs/guides/IndexRoutes.md). This is the same as specifying an `<IndexRoute>` child when using JSX route configs.
 
 ##### `getIndexRoute(location, callback)`
 
@@ -432,7 +432,7 @@ By default, the query parameters will just pass through but you can specify them
 </Route>
 ```
 
-Note that the `<Redirect>` can be placed anywhere in the route hierarchy, though [normal precedence](/docs/guides/basics/RouteMatching.md#precedence) rules apply. If you'd prefer the redirects to be next to their respective routes, the `from` path will match the same as a regular route `path`.
+Note that the `<Redirect>` can be placed anywhere in the route hierarchy, though [normal precedence](/docs/guides/RouteMatching.md#precedence) rules apply. If you'd prefer the redirects to be next to their respective routes, the `from` path will match the same as a regular route `path`.
 
 ```js
 <Route path="course/:courseId">
@@ -561,7 +561,7 @@ class Users extends React.Component {
 
 ## Histories
 
-For more details, please see the [histories guide](/docs/guides/basics/Histories.md).
+For more details, please see the [histories guide](/docs/guides/Histories.md).
 
 ### `browserHistory`
 `browserHistory` uses the HTML5 History API when available, and falls back to full refreshes otherwise. `browserHistory` requires additional configuration on the server side to serve up URLs, but is the generally preferred solution for modern web pages.

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -249,4 +249,4 @@ You can also access parameters from the query string. For instance, if you're on
 
 That's the gist of React Router. Application UIs are boxes inside of boxes inside of boxes; now you can keep those boxes in sync with the URL and link to them easily.
 
-The docs about [route configuration](/docs/guides/basics/RouteConfiguration.md) describe more of the router's features in depth.
+The docs about [route configuration](/docs/guides/RouteConfiguration.md) describe more of the router's features in depth.

--- a/docs/guides/DynamicRouting.md
+++ b/docs/guides/DynamicRouting.md
@@ -8,7 +8,7 @@ It's important that changes deep down in the application don't require changes a
 
 A router is the perfect place to handle code splitting: it's responsible for setting up your views.
 
-React Router does all of its [path matching](/docs/guides/basics/RouteMatching.md) and component fetching asynchronously, which allows you to not only load up the components lazily, *but also lazily load the route configuration*. You really only need one route definition in your initial bundle, the router can resolve the rest on demand.
+React Router does all of its [path matching](/docs/guides/RouteMatching.md) and component fetching asynchronously, which allows you to not only load up the components lazily, *but also lazily load the route configuration*. You really only need one route definition in your initial bundle, the router can resolve the rest on demand.
 
 Routes may define [`getChildRoutes`](/docs/API.md#getchildrouteslocation-callback), [`getIndexRoute`](/docs/API.md#getindexroutelocation-callback), and [`getComponents`](/docs/API.md#getcomponentslocation-callback) methods. These are asynchronous and only called when needed. We call it "gradual matching". React Router will gradually match the URL and fetch only the amount of route configuration and components it needs to match the URL and render.
 

--- a/upgrade-guides/v1.0.0.md
+++ b/upgrade-guides/v1.0.0.md
@@ -68,7 +68,7 @@ render(<Router history={history}>{routes}</Router>, el)
 
 If you do not specify a history type (as in the example above) then you will notice some unusual behaviour after updating to 1.0.0. With the default hash based routing a querystring entry not defined by yourself will start appearing in your URLs called `_k`. An example of how it looks is this: `?_k=umhx1s`
 
-This is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/basics/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
+This is intended and part of [createHashHistory](https://github.com/rackt/react-router/blob/master/docs/guides/Histories.md#createhashhistory) (which is the default history approach used if one is not specified). You can read more about the feature [here](https://github.com/rackt/react-router/blob/master/docs/guides/Histories.md#what-is-that-_kckuvup-junk-in-the-url) and how to opt out [here](https://rackt.github.io/history/stable/HashHistoryCaveats.html).
 
 ### Route Config
 


### PR DESCRIPTION
The folder `basics` doesn't exist anywhere